### PR TITLE
GET /invoices/{accountId}

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,6 +11,8 @@ lazy val root = (project in file("."))
       "org.scalaj"      %% "scalaj-http"  % "2.4.2",
       "com.lihaoyi"     %% "upickle"      % "1.1.0",
       "org.scalameta"   %% "munit"        % "0.7.9"   % Test,
+      "com.gu"          %% "spy"          % "0.1.1",
+      "org.scala-lang.modules" %% "scala-async" % "1.0.0-M1"
     ),
     testFrameworks += new TestFramework("munit.Framework"),
     assemblyJarName := "invoicing-api.jar",
@@ -18,12 +20,16 @@ lazy val root = (project in file("."))
     riffRaffUploadArtifactBucket := Option("riffraff-artifact"),
     riffRaffUploadManifestBucket := Option("riffraff-builds"),
     riffRaffManifestProjectName := "support:invoicing-api",
-    riffRaffArtifactResources += (file("cfn.yaml"), "cfn/cfn.yaml")
+    riffRaffArtifactResources += (file("cfn.yaml"), "cfn/cfn.yaml"),
+    scalacOptions ++= Seq(
+      "-Xasync"
+    )
   )
 
 lazy val deployAwsLambda = taskKey[Unit]("Directly update AWS lambda code from DEV instead of via RiffRaff for faster feedback loop")
 deployAwsLambda := {
   import scala.sys.process._
   assembly.value
-  "aws lambda update-function-code --function-name invoicing-api-refund-CODE --zip-file fileb://target/scala-2.13/invoicing-api.jar --profile membership --region eu-west-1" !
+  "aws lambda update-function-code --function-name invoicing-api-refund-CODE --zip-file fileb://target/scala-2.13/invoicing-api.jar --profile membership --region eu-west-1".!
+  "aws lambda update-function-code --function-name invoicing-api-invoices-CODE --zip-file fileb://target/scala-2.13/invoicing-api.jar --profile membership --region eu-west-1".!
 }

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: "2010-09-09"
 
-Description: Zuora invoice management (refunds)
+Description: Zuora invoice management such as refunds, downloading PDF invoices
 
 Parameters:
   Stage:
@@ -20,7 +20,6 @@ Resources:
   # ****************************************************************************
   # Alarms
   # ****************************************************************************
-
   FailedRefundAlarm:
     Type: AWS::CloudWatch::Alarm
     Condition: IsProd
@@ -43,6 +42,30 @@ Resources:
     DependsOn:
       - InvoicingLambdaRole
 
+  FailedInvoicesAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: IsProd
+    Properties:
+      AlarmName: "URGENT 9-5 - PROD: Failed to fetch Zuora invoice by account"
+      AlarmDescription: |
+        - manage-frontend user will not be able to see/download invoices
+        - https://github.com/guardian/invoicing-api/blob/master/src/main/scala/com/gu/invoicing/invoice/README.md
+        - export AWS_DEFAULT_REGION=eu-west-1 && awslogs get --profile membership /aws/lambda/invoicing-api-invoices-PROD --start='DD/mm/yyyy HH:MM' --end='DD/mm/yyyy HH:MM'
+      AlarmActions:
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:MarioTest
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      Dimensions:
+        - Name: FunctionName
+          Value: !Ref InvoicesLambda
+      EvaluationPeriods: 1
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Period: 300
+      Statistic: Sum
+      Threshold: 1
+      TreatMissingData: notBreaching
+    DependsOn:
+      - InvoicingLambdaRole
 
   # ****************************************************************************
   # Lambdas
@@ -68,40 +91,34 @@ Resources:
     DependsOn:
       - InvoicingLambdaRole
 
+  InvoicesLambda:
+    Type: AWS::Lambda::Function
+    Properties:
+      Description: Retrieve all invoices with payment methods by accountId
+      FunctionName: !Sub invoicing-api-invoices-${Stage}
+      Code:
+        S3Bucket: membership-dist
+        S3Key: !Sub support/${Stage}/invoicing-api/invoicing-api.jar
+      Handler: com.gu.invoicing.invoice.Lambda::handleRequest
+      Environment:
+        Variables:
+          Stage: !Ref Stage
+          Config: !Sub '{{resolve:ssm:/invoicing-api/${Stage}/config:1}}'
+      Role: !GetAtt InvoicingLambdaRole.Arn
+      MemorySize: 3008
+      Runtime: java8
+      Timeout: 900
+    DependsOn:
+      - InvoicingLambdaRole
+
   # ****************************************************************************
   # API
   # ****************************************************************************
-
   InvoicingApi:
     Type: AWS::ApiGateway::RestApi
     Properties:
       Name: !Sub invoicing-api-${Stage}
       Description: Zuora invoice management (refunds)
-
-  RefundEndpoint:
-    Type: AWS::ApiGateway::Resource
-    Properties:
-      RestApiId: !Ref InvoicingApi
-      ParentId: !GetAtt InvoicingApi.RootResourceId
-      PathPart: refund
-    DependsOn: InvoicingApi
-
-  RefundMethod:
-    Type: AWS::ApiGateway::Method
-    Properties:
-      ApiKeyRequired: true
-      AuthorizationType: NONE
-      RestApiId: !Ref InvoicingApi
-      ResourceId: !Ref RefundEndpoint
-      HttpMethod: POST
-      Integration:
-        Type: AWS_PROXY
-        IntegrationHttpMethod: POST # this for the interaction between API Gateway and Lambda and MUST be POST
-        Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${RefundLambda.Arn}/invocations
-    DependsOn:
-      - InvoicingApi
-      - RefundEndpoint
-      - RefundLambda
 
   InvoicingApiStage:
     Type: AWS::ApiGateway::Stage
@@ -153,6 +170,75 @@ Resources:
       - InvoicingApiKey
       - InvoicingApiUsagePlan
 
+
+  # ****************************************************************************
+  # POST /refund
+  # ****************************************************************************
+  RefundEndpoint:
+    Type: AWS::ApiGateway::Resource
+    Properties:
+      RestApiId: !Ref InvoicingApi
+      ParentId: !GetAtt InvoicingApi.RootResourceId
+      PathPart: refund
+    DependsOn: InvoicingApi
+
+  RefundMethod:
+    Type: AWS::ApiGateway::Method
+    Properties:
+      ApiKeyRequired: true
+      AuthorizationType: NONE
+      RestApiId: !Ref InvoicingApi
+      ResourceId: !Ref RefundEndpoint
+      HttpMethod: POST
+      Integration:
+        Type: AWS_PROXY
+        IntegrationHttpMethod: POST # this for the interaction between API Gateway and Lambda and MUST be POST
+        Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${RefundLambda.Arn}/invocations
+    DependsOn:
+      - InvoicingApi
+      - RefundEndpoint
+      - RefundLambda
+
+  # ****************************************************************************
+  # GET /invoices/{accountId}
+  # ****************************************************************************
+  InvoicesEndpoint:
+    Type: AWS::ApiGateway::Resource
+    Properties:
+      RestApiId: !Ref InvoicingApi
+      ParentId: !GetAtt InvoicingApi.RootResourceId
+      PathPart: invoices
+    DependsOn: InvoicingApi
+
+  InvoicesAccountIdPath:
+    Type: AWS::ApiGateway::Resource
+    Properties:
+      RestApiId: !Ref InvoicingApi
+      ParentId: !Ref InvoicesEndpoint
+      PathPart: "{accountId}"
+    DependsOn:
+      - InvoicingApi
+      - InvoicesEndpoint
+
+  InvoicesEndpointGetMethod:
+    Type: AWS::ApiGateway::Method
+    Properties:
+      AuthorizationType: AWS_IAM
+      ApiKeyRequired: true
+      RestApiId: !Ref InvoicingApi
+      ResourceId: !Ref InvoicesAccountIdPath
+      HttpMethod: GET
+      RequestParameters:
+        method.request.path.accountId: true
+      Integration:
+        Type: AWS_PROXY
+        IntegrationHttpMethod: POST # this for the interaction between API Gateway and Lambda and MUST be POST
+        Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${InvoicesLambda.Arn}/invocations
+    DependsOn:
+      - InvoicingApi
+      - InvoicesLambda
+      - InvoicesAccountIdPath
+
   # ****************************************************************************
   # Access control
   # ****************************************************************************
@@ -166,6 +252,15 @@ Resources:
     DependsOn:
       - RefundLambda
       - RefundMethod
+
+  InvoicesLambdaPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:invokeFunction
+      FunctionName: !Sub invoicing-api-invoices-${Stage}
+      Principal: apigateway.amazonaws.com
+    DependsOn:
+      - InvoicesLambda
 
   InvoicingLambdaRole:
     Type: AWS::IAM::Role
@@ -189,7 +284,9 @@ Resources:
                   - logs:CreateLogStream
                   - logs:PutLogEvents
                   - lambda:InvokeFunction
-                Resource: !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/invoicing-api-refund-${Stage}:log-stream:*
+                Resource:
+                - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/invoicing-api-refund-${Stage}:log-stream:*
+                - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/invoicing-api-invoices-${Stage}:log-stream:*
 
         - PolicyName: ReadPrivateCredentials
           PolicyDocument:

--- a/src/main/scala/com/gu/invoicing/invoice/Cli.scala
+++ b/src/main/scala/com/gu/invoicing/invoice/Cli.scala
@@ -1,0 +1,25 @@
+package com.gu.invoicing.invoice
+
+import com.gu.invoicing.invoice.Log._
+import com.gu.invoicing.invoice.Model._
+import scala.async.Async.{async, await}
+import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.concurrent.duration.Duration.Inf
+import scala.util.chaining._
+import Impl._
+import Program._
+import com.gu.spy._
+
+/**
+ * Create environmental variables with Zuora OAuth credentials:
+ *
+ *   export STAGE = CODE
+ *   export Config = { "clientId": "******", "clientSecret": "*****"}
+ */
+object Cli {
+  def main(args: Array[String]): Unit = {
+    (1 to 4).foreach { _ =>
+      time { Await.result(program(InvoicesInput("someAccountId")), Inf) }
+    }
+  }
+}

--- a/src/main/scala/com/gu/invoicing/invoice/Impl.scala
+++ b/src/main/scala/com/gu/invoicing/invoice/Impl.scala
@@ -75,7 +75,7 @@ object Impl {
             .paidInvoices
             .tap(v => assert(v.length == 1, s"Payment should be associated with only one invoice: $payment"))
             .headOption
-            .map { invoice => invoice.invoiceId -> payment.paymentMethodId }
+            .map { _.invoiceId -> payment.paymentMethodId }
         }.toMap
 
     val paymentMethodById: Map[String, PaymentMethod] = paymentMethods.map(paymentMethod => paymentMethod.Id -> paymentMethod).toMap

--- a/src/main/scala/com/gu/invoicing/invoice/Impl.scala
+++ b/src/main/scala/com/gu/invoicing/invoice/Impl.scala
@@ -1,0 +1,130 @@
+package com.gu.invoicing.invoice
+
+import java.lang.System.getenv
+import java.time.LocalDate
+import com.gu.invoicing.invoice.Model._
+import scalaj.http.Http
+import scala.util.chaining._
+import com.gu.spy._
+
+/**
+ * Zuora API client and implementation details
+ */
+object Impl {
+  lazy val stage = getenv("Stage")
+
+  lazy val zuoraApiHost: String =
+    stage match { case "DEV" | "CODE" => "https://rest.apisandbox.zuora.com"; case "PROD" => "https://rest.zuora.com" }
+
+  lazy val config = read[Config](getenv("Config"))
+
+  lazy val accessToken: String = {
+    Http(s"$zuoraApiHost/oauth/token")
+      .postForm(Seq(
+        "client_id" -> config.clientId,
+        "client_secret" -> config.clientSecret,
+        "grant_type" -> "client_credentials"
+      ))
+      .asString
+      .body
+      .pipe(read[AccessToken](_))
+      .access_token
+  }
+
+  def getInvoices(account: String): List[Invoice] = {
+    Http(s"$zuoraApiHost/v1/transactions/invoices/accounts/$account")
+      .header("Authorization", s"Bearer ${accessToken}")
+      .asString
+      .body
+      .pipe(read[Invoices](_))
+      .invoices
+      .filter { _.amount >= 0.0 }
+  }
+
+  def getPayments(account: String): List[Payment] = {
+    Http(s"$zuoraApiHost/v1/transactions/payments/accounts/$account")
+      .header("Authorization", s"Bearer ${accessToken}")
+      .asString
+      .body
+      .pipe(read[Payments](_))
+      .payments
+  }
+
+  def getPaymentMethods(accountId: String): List[PaymentMethod] = {
+    Http(s"$zuoraApiHost/v1/action/query")
+      .header("Authorization", s"Bearer ${accessToken}")
+      .header("Content-Type", "application/json")
+      .postData(s"""{"queryString": "select BankTransferType, CreditCardExpirationMonth, CreditCardExpirationYear, BankTransferAccountNumberMask, LastFailedSaleTransactionDate, LastTransactionDateTime, LastTransactionStatus, Name, NumConsecutiveFailures, PaymentMethodStatus, Type, ID, MandateID, PaypalBAID, SecondTokenID, TokenID, AccountID, Active, Country, CreatedById, CreatedDate, CreditCardType, DeviceSessionId, IdentityNumber, MandateCreationDate, MandateReceived, MandateUpdateDate, MaxConsecutivePaymentFailures, PaymentRetryWindow, TotalNumberOfErrorPayments, TotalNumberOfProcessedPayments, UpdatedById, UpdatedDate, UseDefaultRetryRule, CreditCardMaskNumber from PaymentMethod where AccountId = '$accountId'"}""")
+      .method("POST")
+      .asString
+      .body
+      .pipe(read[PaymentMethods](_))
+      .records
+  }
+
+  def getPaymentMethod(
+    invoiceId: String,
+    invoices: List[Invoice],
+    payments: List[Payment],
+    paymentMethods: List[PaymentMethod]
+  ): PaymentMethod = {
+    val paymentMethodIdByInvoiceId: Map[String, String] =
+      payments
+        .flatMap { payment =>
+          payment
+            .paidInvoices
+            .tap(v => assert(v.length == 1, s"Payment should be associated with only one invoice: $payment"))
+            .headOption
+            .map { invoice => invoice.invoiceId -> payment.paymentMethodId }
+        }.toMap
+
+    val paymentMethodById: Map[String, PaymentMethod] = paymentMethods.map(paymentMethod => paymentMethod.Id -> paymentMethod).toMap
+
+    val paymentMethodByInvoiceId: Map[String, PaymentMethod] =
+      invoices.map { invoice =>
+        invoice.id -> paymentMethodById(paymentMethodIdByInvoiceId(invoice.id))
+      }.toMap
+
+    paymentMethodByInvoiceId(invoiceId)
+  }
+
+  def time[R](block: => R): R = {
+    val t0 = System.nanoTime()
+    val result = block    // call-by-name
+    val t1 = System.nanoTime()
+    println("Elapsed time: " + (t1 - t0) / 1_000_000_000d + "s")
+    result
+  }
+
+  def joinInvoicesWithPayment(
+    invoices: List[Invoice],
+    payments: List[Payment],
+    paymentMethods: List[PaymentMethod],
+  ): List[InvoiceWithPayment] = {
+    invoices.map { invoice =>
+      InvoiceWithPayment(
+        invoice,
+        getPaymentMethod(invoice.id, invoices, payments, paymentMethods),
+      )
+    }
+  }
+
+  /**
+   * Currently we can handle invoices that have only one Subscriptions, so make sure
+   * all the invoice items have the same subscriptionId field, and return on of them
+   */
+  def allInvoicesShouldHaveASingleSubscription(invoices: List[Invoice]): Unit = {
+    invoices.foreach { invoice =>
+      assert(
+        invoice.invoiceItems.groupBy(_.subscriptionName).keys.size == 1,
+        s"There should be only a single subscription per invoice: $invoices"
+      )
+    }
+  }
+
+  def transformToMmaExpectedFormat(
+    invoicesWithPayment: List[InvoiceWithPayment]
+  ): List[MmaInvoiceWithPayment] = {
+    invoicesWithPayment.map(MmaInvoiceWithPayment.apply)
+  }
+}

--- a/src/main/scala/com/gu/invoicing/invoice/Lambda.scala
+++ b/src/main/scala/com/gu/invoicing/invoice/Lambda.scala
@@ -1,0 +1,45 @@
+package com.gu.invoicing.invoice
+
+import java.io.{InputStream, OutputStream}
+
+import com.gu.invoicing.invoice.Log._
+import com.gu.invoicing.invoice.Model._
+import com.gu.invoicing.invoice.Program._
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration.Inf
+import scala.util.chaining._
+
+/**
+ * Example test event for running the lambda from AWS Console
+ * {
+ *   "pathParameters": {
+ *     "accountId": "123456qwerty"
+ *   }
+ * }
+ */
+object Lambda {
+  def handleRequest(input: InputStream, output: OutputStream): Unit = {
+    input
+      .pipe { deserialiseStream    }
+      .tap  { info[InvoicesInput]  }
+      .pipe { program              }
+      .pipe { Await.result(_, Inf) }
+      .tap  { info[InvoicesOutput] }
+      .pipe { serialiseToStream    }
+
+    def deserialiseStream(inputStream: InputStream): InvoicesInput = {
+      inputStream
+        .pipe { read[ApiGatewayInput](_) }
+        .pathParameters
+        .accountId
+        .pipe { InvoicesInput }
+    }
+    def serialiseToStream(invoicesOutput: InvoicesOutput): Unit  = {
+      invoicesOutput
+        .pipe { invoicesOut => ApiGatewayOutput(200, write(invoicesOut)) }
+        .pipe { apiGatewayOut => write(apiGatewayOut) }
+        .pipe { _.getBytes }
+        .pipe { output.write }
+    }
+  }
+}

--- a/src/main/scala/com/gu/invoicing/invoice/Log.scala
+++ b/src/main/scala/com/gu/invoicing/invoice/Log.scala
@@ -1,0 +1,17 @@
+package com.gu.invoicing.invoice
+
+import Model._
+/**
+ * Log deserialised JSON objects.
+ */
+object Log extends {
+  def info[P <: Product : Writer](p: P): Unit = info(write(p))
+  def warn[P <: Product : Writer](p: P): Unit = warn(write(p))
+  def error[P <: Product : Writer](p: P): Unit = error(write(p))
+
+  private val logger = java.util.logging.Logger.getGlobal
+  private object ErrorLevel extends java.util.logging.Level("ERROR", 950)
+  private def info(s: String): Unit = logger.info(s)
+  private def warn(s: String): Unit = logger.warning(s)
+  private def error(s: String): Unit = logger.log(ErrorLevel, s)
+}

--- a/src/main/scala/com/gu/invoicing/invoice/Model.scala
+++ b/src/main/scala/com/gu/invoicing/invoice/Model.scala
@@ -1,0 +1,274 @@
+package com.gu.invoicing.invoice
+
+import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeFormatter.ofPattern
+import java.time.{LocalDate, LocalDateTime}
+import java.util.UUID
+import com.gu.spy._
+
+/**
+ * Needed for upickle to handle optional fields
+ * http://www.lihaoyi.com/upickle/#CustomConfiguration
+ */
+class OptionPickler extends upickle.AttributeTagged {
+  implicit def optionWriter[T: Writer]: Writer[Option[T]] =
+    implicitly[Writer[T]].comap[Option[T]] {
+      case None => null.asInstanceOf[T]
+      case Some(x) => x
+    }
+
+  implicit def optionReader[T: Reader]: Reader[Option[T]] = {
+    new Reader.Delegate[Any, Option[T]](implicitly[Reader[T]].map(Some(_))){
+      override def visitNull(index: Int) = None
+    }
+  }
+}
+
+/**
+ * Data models and JSON codecs
+ */
+object Model extends OptionPickler {
+  case class Config(clientId: String, clientSecret: String)
+  case class AccessToken(access_token: String)
+
+  case class Invoices(
+    invoices: List[Invoice],
+    success: Boolean
+  )
+  case class Invoice(
+    id: String,
+    accountId: String,
+    accountNumber: String,
+    accountName: String,
+    invoiceDate: LocalDate,
+    invoiceNumber: String,
+    dueDate: LocalDate,
+    invoiceTargetDate: LocalDate,
+    amount: BigDecimal,
+    balance: BigDecimal,
+    creditBalanceAdjustmentAmount: BigDecimal,
+    createdBy: String,
+    status: String,
+    body: String,
+    invoiceItems: List[InvoiceItem],
+    invoiceFiles: List[InvoiceFile],
+  )
+  case class InvoiceItem(
+    id: String,
+    subscriptionName: String,
+    subscriptionId: String,
+    serviceStartDate: LocalDate,
+    serviceEndDate: LocalDate,
+    chargeAmount: BigDecimal,
+    chargeDescription: String,
+    chargeName: String,
+    chargeId: String,
+    productName: String,
+    quantity: BigDecimal,
+    taxAmount: BigDecimal,
+    unitOfMeasure: String,
+    chargeDate: String, // FIXME this has different format from other kinds of localdatetimes
+    chargeType: String,
+    processingType: String,
+    appliedToItemId: Option[String]
+  )
+  case class InvoiceFile(
+    id: String,
+    versionNumber: Int,
+    pdfFileUrl: String
+  )
+
+  case class InvoiceWithPayment(
+    subscriptionName: String,
+    date: LocalDate,
+    paymentMethod: PaymentMethod,
+    price: Double,
+    downloadUrl: String,
+    invoiceId: String
+  )
+
+  /**
+   * Subscription name is not available from the top level Invoice object because Invoice can be associated with
+   * multiple subscriptions, however current MMA design wants to group invoices per subscription.
+   */
+  object InvoiceWithPayment {
+    def apply(
+      invoice: Invoice,
+      paymentMethod: PaymentMethod,
+    ): InvoiceWithPayment = {
+      // PDF invoice files are in reverse chronological order meaning most recent version is first
+      // https://www.zuora.com/developer/api-reference/#operation/GET_InvoiceFiles
+      val downloadUrl =
+        invoice
+          .invoiceFiles
+          .headOption
+          .getOrElse(throw new AssertionError(s"PDF file should exist for each invoice: $invoice"))
+          .pdfFileUrl match { case s"/v1/files/$fileId" => fileId }
+
+      // Currently we handle only invoices with single subscription, so any invoice item should do for getting the subscription name
+      val subscriptionName =
+        invoice
+          .invoiceItems
+          .headOption
+          .getOrElse(throw new AssertionError(s"At least one invoice item should always exist: $invoice"))
+          .subscriptionName
+
+      new InvoiceWithPayment(
+        subscriptionName = subscriptionName,
+        date = invoice.invoiceDate,
+        paymentMethod = paymentMethod,
+        price = invoice.amount.toDouble,
+        downloadUrl = downloadUrl,
+        invoiceId = invoice.id
+      )
+    }
+  }
+
+  /**
+   * This is the model expected by manage-frontend. I kept is as separate concept from InvoiceWithPayment
+   * as it is likely to keep changing in the initial stages.
+   */
+  case class MmaInvoiceWithPayment(
+    invoiceId: String,
+    subscriptionName: String,
+    date: LocalDate,
+    downloadUrl: String,
+    price: Double,
+    paymentMethod: String,
+    last4: Option[String] = None // for card and direct debit
+  )
+
+  object MmaInvoiceWithPayment {
+    def apply(invoiceWithPayment: InvoiceWithPayment): MmaInvoiceWithPayment = {
+      val mmaResponse = new MmaInvoiceWithPayment(
+        invoiceId = invoiceWithPayment.invoiceId,
+        subscriptionName = invoiceWithPayment.subscriptionName,
+        date = invoiceWithPayment.date,
+        downloadUrl = invoiceWithPayment.downloadUrl,
+        price = invoiceWithPayment.price,
+        paymentMethod = invoiceWithPayment.paymentMethod.Type
+      )
+
+      val paymentMethod = invoiceWithPayment.paymentMethod
+      import paymentMethod._
+      paymentMethod.Type match {// ACH, BankTransfer, Cash, Check, CreditCard, CreditCardReferenceTransaction, DebitCard, Other, PayPal, WireTransfer
+        case "CreditCard" | "CreditCardReferenceTransaction" | "DebitCard" =>
+          mmaResponse.copy(last4 = CreditCardMaskNumber)
+
+        case "BankTransfer" =>
+          mmaResponse.copy(last4 = BankTransferAccountNumberMask.map(_.dropWhile(_ == '*')))
+
+        case "PayPal" =>
+          mmaResponse.copy(last4 = None)
+
+        case _ =>
+          throw new RuntimeException(s"Unexpected payment method: ${paymentMethod.spy}")
+      }
+    }
+  }
+
+  case class InvoicesOutput(
+    invoices: List[MmaInvoiceWithPayment]
+  )
+  case class InvoicesInput(
+    accountId: String
+  )
+  case class Payment(
+    id: String,
+    accountId: String,
+    accountNumber: String,
+    accountName: String,
+    `type`: String,
+    effectiveDate: LocalDate,
+    paymentNumber: String,
+    paymentMethodId: String,
+    amount: BigDecimal,
+    paidInvoices: List[PaidInvoice],
+    gatewayTransactionNumber: String,
+    status: String,
+  )
+
+  case class PaidInvoice(
+    invoiceId: String,
+    invoiceNumber: String,
+    appliedPaymentAmount: BigDecimal
+  )
+
+  case class Payments(
+    payments: List[Payment],
+    success: Boolean
+  )
+
+  case class PaymentMethod(
+    Id: String,
+    AccountId: String,
+    LastTransactionDateTime: LocalDateTime,
+    NumConsecutiveFailures: Int,
+    TotalNumberOfProcessedPayments: Int,
+    UpdatedById: String,
+    CreatedDate: LocalDateTime,
+    UseDefaultRetryRule: Boolean,
+    LastTransactionStatus: String,
+    PaymentMethodStatus: String,
+    UpdatedDate: LocalDateTime,
+    CreatedById: String,
+    TotalNumberOfErrorPayments: Int,
+    Active: Boolean,
+    Type: String,
+
+    // Bank Account (Direct Debit)
+    BankCode: Option[String] = None,
+    BankTransferAccountName: Option[String] = None,
+    BankTransferAccountNumberMask: Option[String] = None,
+
+    // PayPal
+    PaypalEmail: Option[String] = None,
+
+    // Credit Card
+    CreditCardMaskNumber: Option[String] = None,
+    CreditCardExpirationMonth: Option[String] = None,
+    CreditCardExpirationYear: Option[String] = None,
+    CreditCardType: Option[String] = None,
+   )
+
+  case class PaymentMethods(
+    records: List[PaymentMethod],
+    done: Boolean,
+    size: Int
+  )
+
+  implicit val bigDecimalRW: ReadWriter[BigDecimal] = readwriter[Double].bimap[BigDecimal](_.toDouble, double => BigDecimal(double.toString))
+  implicit val localDateRW: ReadWriter[LocalDate] = readwriter[String].bimap[LocalDate](_.toString, LocalDate.parse(_, ofPattern("yyyy-MM-dd")))
+  implicit val localDateTimeRW: ReadWriter[LocalDateTime] = readwriter[String].bimap[LocalDateTime](_.toString, LocalDateTime.parse(_, DateTimeFormatter.ISO_OFFSET_DATE_TIME)) // ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSXXX")
+
+  implicit val configRW: ReadWriter[Config] = macroRW
+  implicit val accessTokenRW: ReadWriter[AccessToken] = macroRW
+
+  implicit val invoicesRW: ReadWriter[Invoices] = macroRW
+  implicit val invoiceRW: ReadWriter[Invoice] = macroRW
+  implicit val invoiceItemRW: ReadWriter[InvoiceItem] = macroRW
+  implicit val invoiceFileRW: ReadWriter[InvoiceFile] = macroRW
+
+  implicit val paymentRW: ReadWriter[Payment] = macroRW
+  implicit val paidInvoiceRW: ReadWriter[PaidInvoice] = macroRW
+  implicit val paymentsRW: ReadWriter[Payments] = macroRW
+
+  implicit val paymentMethodRW: ReadWriter[PaymentMethod] = macroRW
+  implicit val paymentMethodsRW: ReadWriter[PaymentMethods] = macroRW
+
+  implicit val invoiceWithPaymentRW: ReadWriter[InvoiceWithPayment] = macroRW
+  implicit val mmaInvoiceWithPaymentRW: ReadWriter[MmaInvoiceWithPayment] = macroRW
+
+  // https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-input-format
+  case class AccountId(accountId: String)
+  case class ApiGatewayInput(pathParameters: AccountId)
+
+  // https://aws.amazon.com/premiumsupport/knowledge-center/malformed-502-api-gateway/
+  case class ApiGatewayOutput(statusCode: Int, body: String)
+
+  implicit val AccountIdRW: ReadWriter[AccountId] = macroRW
+  implicit val awsBodyRW: ReadWriter[ApiGatewayInput] = macroRW
+  implicit val apiGatewayOutputRW: ReadWriter[ApiGatewayOutput] = macroRW
+  implicit val invoicesInputRW: ReadWriter[InvoicesInput] = macroRW
+  implicit val invoicesOutputRW: ReadWriter[InvoicesOutput] = macroRW
+}

--- a/src/main/scala/com/gu/invoicing/invoice/Model.scala
+++ b/src/main/scala/com/gu/invoicing/invoice/Model.scala
@@ -83,7 +83,7 @@ object Model extends OptionPickler {
     date: LocalDate,
     paymentMethod: PaymentMethod,
     price: Double,
-    downloadUrl: String,
+    pdfFileId: String, // used to download the file
     invoiceId: String
   )
 
@@ -98,7 +98,7 @@ object Model extends OptionPickler {
     ): InvoiceWithPayment = {
       // PDF invoice files are in reverse chronological order meaning most recent version is first
       // https://www.zuora.com/developer/api-reference/#operation/GET_InvoiceFiles
-      val downloadUrl =
+      val pdfFileId =
         invoice
           .invoiceFiles
           .headOption
@@ -118,7 +118,7 @@ object Model extends OptionPickler {
         date = invoice.invoiceDate,
         paymentMethod = paymentMethod,
         price = invoice.amount.toDouble,
-        downloadUrl = downloadUrl,
+        pdfFileId = pdfFileId,
         invoiceId = invoice.id
       )
     }
@@ -144,7 +144,7 @@ object Model extends OptionPickler {
         invoiceId = invoiceWithPayment.invoiceId,
         subscriptionName = invoiceWithPayment.subscriptionName,
         date = invoiceWithPayment.date,
-        downloadUrl = invoiceWithPayment.downloadUrl,
+        downloadUrl = invoiceWithPayment.pdfFileId,
         price = invoiceWithPayment.price,
         paymentMethod = invoiceWithPayment.paymentMethod.Type
       )

--- a/src/main/scala/com/gu/invoicing/invoice/Model.scala
+++ b/src/main/scala/com/gu/invoicing/invoice/Model.scala
@@ -83,7 +83,7 @@ object Model extends OptionPickler {
     date: LocalDate,
     paymentMethod: PaymentMethod,
     price: Double,
-    pdfFileUrl: String, /* invoices/{accountId}/{fileId} */
+    pdfPath: String, /* invoices/{accountId}/{fileId} */
     invoiceId: String
   )
 
@@ -98,7 +98,7 @@ object Model extends OptionPickler {
     ): InvoiceWithPayment = {
       // PDF invoice files are in reverse chronological order meaning most recent version is first
       // https://www.zuora.com/developer/api-reference/#operation/GET_InvoiceFiles
-      val pdfFileUrl =
+      val pdfPath =
         invoice
           .invoiceFiles
           .headOption
@@ -118,7 +118,7 @@ object Model extends OptionPickler {
         date = invoice.invoiceDate,
         paymentMethod = paymentMethod,
         price = invoice.amount.toDouble,
-        pdfFileUrl = pdfFileUrl,
+        pdfPath = pdfPath,
         invoiceId = invoice.id
       )
     }
@@ -132,7 +132,7 @@ object Model extends OptionPickler {
     invoiceId: String,
     subscriptionName: String,
     date: LocalDate,
-    pdfFileUrl: String,
+    pdfPath: String,
     price: Double,
     paymentMethod: String,
     last4: Option[String] = None // for card and direct debit
@@ -144,7 +144,7 @@ object Model extends OptionPickler {
         invoiceId = invoiceWithPayment.invoiceId,
         subscriptionName = invoiceWithPayment.subscriptionName,
         date = invoiceWithPayment.date,
-        pdfFileUrl = invoiceWithPayment.pdfFileUrl,
+        pdfPath = invoiceWithPayment.pdfPath,
         price = invoiceWithPayment.price,
         paymentMethod = invoiceWithPayment.paymentMethod.Type
       )

--- a/src/main/scala/com/gu/invoicing/invoice/Model.scala
+++ b/src/main/scala/com/gu/invoicing/invoice/Model.scala
@@ -83,7 +83,7 @@ object Model extends OptionPickler {
     date: LocalDate,
     paymentMethod: PaymentMethod,
     price: Double,
-    pdfFileId: String, // used to download the file
+    pdfFileUrl: String, /* invoices/{accountId}/{fileId} */
     invoiceId: String
   )
 
@@ -98,12 +98,12 @@ object Model extends OptionPickler {
     ): InvoiceWithPayment = {
       // PDF invoice files are in reverse chronological order meaning most recent version is first
       // https://www.zuora.com/developer/api-reference/#operation/GET_InvoiceFiles
-      val pdfFileId =
+      val pdfFileUrl =
         invoice
           .invoiceFiles
           .headOption
           .getOrElse(throw new AssertionError(s"PDF file should exist for each invoice: $invoice"))
-          .pdfFileUrl match { case s"/v1/files/$fileId" => fileId }
+          .pdfFileUrl match { case s"/v1/files/$fileId" => s"invoices/${invoice.accountId}/$fileId" }
 
       // Currently we handle only invoices with single subscription, so any invoice item should do for getting the subscription name
       val subscriptionName =
@@ -118,7 +118,7 @@ object Model extends OptionPickler {
         date = invoice.invoiceDate,
         paymentMethod = paymentMethod,
         price = invoice.amount.toDouble,
-        pdfFileId = pdfFileId,
+        pdfFileUrl = pdfFileUrl,
         invoiceId = invoice.id
       )
     }
@@ -132,7 +132,7 @@ object Model extends OptionPickler {
     invoiceId: String,
     subscriptionName: String,
     date: LocalDate,
-    downloadUrl: String,
+    pdfFileUrl: String,
     price: Double,
     paymentMethod: String,
     last4: Option[String] = None // for card and direct debit
@@ -144,7 +144,7 @@ object Model extends OptionPickler {
         invoiceId = invoiceWithPayment.invoiceId,
         subscriptionName = invoiceWithPayment.subscriptionName,
         date = invoiceWithPayment.date,
-        downloadUrl = invoiceWithPayment.pdfFileId,
+        pdfFileUrl = invoiceWithPayment.pdfFileUrl,
         price = invoiceWithPayment.price,
         paymentMethod = invoiceWithPayment.paymentMethod.Type
       )

--- a/src/main/scala/com/gu/invoicing/invoice/Program.scala
+++ b/src/main/scala/com/gu/invoicing/invoice/Program.scala
@@ -1,0 +1,27 @@
+package com.gu.invoicing.invoice
+
+import com.gu.invoicing.invoice.Model._
+import scala.async.Async.{async, await}
+import scala.concurrent.Future
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.util.chaining._
+import Impl._
+import com.gu.spy._
+
+object Program { /** Main business logic */
+  def program(input: InvoicesInput): Future[InvoicesOutput] = async {
+    val InvoicesInput(accountId) = input
+
+    val invoicesF              = async(getInvoices(accountId))
+    val paymentsF              = async(getPayments(accountId))
+    val paymentMethodsF        = async(getPaymentMethods(accountId))
+    val positiveInvoices       = await(invoicesF)
+    val payments               = await(paymentsF)
+    val paymentMethods         = await(paymentMethodsF)
+    val _                      = allInvoicesShouldHaveASingleSubscription(positiveInvoices)
+    val invoicesWithPayment    = joinInvoicesWithPayment(positiveInvoices, payments, paymentMethods)
+    val mmaInvoicesWithPayment = transformToMmaExpectedFormat(invoicesWithPayment)
+
+    InvoicesOutput(mmaInvoicesWithPayment)
+  }
+}

--- a/src/main/scala/com/gu/invoicing/invoice/README.md
+++ b/src/main/scala/com/gu/invoicing/invoice/README.md
@@ -1,0 +1,71 @@
+## Get all invoices by account
+
+The request requires api key as well as AWS Signature
+
+Example client manage-frontend PR: https://github.com/guardian/manage-frontend/pull/465
+
+**Request:**
+
+```
+GET /invoices/{accountId}
+Host: https://{apiGatewayId}.execute-api.{region}.amazonaws.com/{STAGE}
+Content-Type: application/json
+x-api-key: ********
+X-Amz-Security-Token: ******** 
+X-Amz-Date: ********
+Authorization: ******** 
+```
+
+**Response:**
+
+```
+{
+    "invoices": [
+        {
+            "invoiceId": "1234567899qwertyuio",
+            "subscriptionName": "A-S0000000",
+            "date": "2020-08-05",
+            "downloadUrl": "9876543jhgfdshgfds",
+            "price": 813.48,
+            "paymentMethod": "BankTransfer",
+            "last4": "9911"
+        }
+    ]
+}
+```
+
+### How to test in CODE
+
+#### With CLI 
+
+1. Get invoicing-api+uat@guardian.co.uk Zuora OAuth client credentials
+1. Follow docs in `Cli.scala` and create `Stage` and `Config` environmental variables
+1. Performance can be estimated with something like 
+    ```
+    time { Await.result(program(InvoicesInput("someAccountId")), Inf) }
+    ```
+
+#### With Lambda
+
+1. Get fresh Janus credentials
+1. `Program.scala` contains main business logic 
+1. `deployAwsLambda` will upload modified lambda package
+1. In AWS Lambda console create test event with reflects `GET /invoices/{accountId}`
+    ```
+    {
+      "pathParameters": {
+        "accountId": "1234567qwerty"
+      }
+    }
+    ```
+1. Tail logs 
+    ```
+    export AWS_DEFAULT_REGION=eu-west-1 && awslogs get --profile membership /aws/lambda/invoicing-api-invoices-CODE --watch
+    ```
+   
+#### With API Gateway (Postman)
+
+1. HTTP request will have to be signed with AWS signature
+1. Get fresh janus credentials
+1. Paste them in `Postman | Auth | AWS Signature`
+1. Don't forget also the API key `x-api-key`

--- a/src/main/scala/com/gu/invoicing/invoice/README.md
+++ b/src/main/scala/com/gu/invoicing/invoice/README.md
@@ -25,7 +25,7 @@ Authorization: ********
             "invoiceId": "1234567899qwertyuio",
             "subscriptionName": "A-S0000000",
             "date": "2020-08-05",
-            "pdfFileUrl": "invoices/anAccountId/afileId",
+            "pdfPath": "invoices/anAccountId/afileId",
             "price": 813.48,
             "paymentMethod": "BankTransfer",
             "last4": "9911"

--- a/src/main/scala/com/gu/invoicing/invoice/README.md
+++ b/src/main/scala/com/gu/invoicing/invoice/README.md
@@ -25,7 +25,7 @@ Authorization: ********
             "invoiceId": "1234567899qwertyuio",
             "subscriptionName": "A-S0000000",
             "date": "2020-08-05",
-            "downloadUrl": "9876543jhgfdshgfds",
+            "pdfFileUrl": "invoices/anAccountId/afileId",
             "price": 813.48,
             "paymentMethod": "BankTransfer",
             "last4": "9911"


### PR DESCRIPTION
## What does this change?

https://trello.com/c/ggqXe1rg/1492-goal-expose-invoices-for-the-billing-tab

Return 

```
{
    "invoices": [
        {
            "invoiceId": "1234567899qwertyuio",
            "subscriptionName": "A-S0000000",
            "date": "2020-08-05",
            "pdfPath": "invoices/afileId",
            "price": 813.48,
            "paymentMethod": "BankTransfer",
            "last4": "9911"
        }
    ]
}
```

when server-side of manage-frontend requests `GET /invoices`, which will be rendered as something like

![image](https://user-images.githubusercontent.com/13835317/89781931-2c724c00-db0c-11ea-9a48-84a1f9f152d2.png)

### Key implementation details

- The field `"pdfPath":  "invoices/afileId"` corresponds to `fileId` of Zuora [GET_InvoiceFiles](https://www.zuora.com/developer/api-reference/#operation/GET_InvoiceFiles) which will be used to download the PDF invoice file (implemented in separate PR). 
- MMA will need to send an x-identity-id + API key + [AWS signature](https://github.com/guardian/manage-frontend/pull/465).
- Main business logic is in `Program.scala`
- Implementation uses Scala 2.13.3 [`-Xasync`](https://github.com/scala/scala-async) compiler flag to enable the following direct style of programming

```
val invoicesF              = async(getInvoices(accountId))
val paymentsF              = async(getPayments(accountId))
val paymentMethodsF        = async(getPaymentMethods(accountId))
val positiveInvoices       = await(invoicesF)
val payments               = await(paymentsF)
val paymentMethods         = await(paymentMethodsF)
val _                      = allInvoicesShouldHaveASingleSubscription(positiveInvoices)
val invoicesWithPayment    = joinInvoicesWithPayment(positiveInvoices, payments, paymentMethods)
val mmaInvoicesWithPayment = transformToMmaExpectedFormat(invoicesWithPayment)
```

instead of equivalent monadic for-comprehension 

```
val invoicesF              = Future(getInvoices(accountId)))
val paymentsF              = Future(getPayments(accountId)))
val paymentMethodsF        = Future(getPaymentMethods(accountId)))
for {
  positiveInvoices <- invoicesF
  payments         <- paymentsF
  paymentMethods   <- paymentMethodsF
} yield ...
```
- Performance breakdown is approx. as follows
  - cold =  900 ms Lambda warmup + 500 ms Zuora auth + 1600 ms business logic
  - warm = 1500 ms total
- Lambda package size at approx 7 MB
- Approach of fail "deny + fail fast + alarm + iterate" to root out edge cases before thinking about generalisation

### Limitations

- It does not handle invoices with multiple subscriptions

## How to test

#### With CLI 

1. Get invoicing-api+uat@guardian.co.uk Zuora OAuth client credentials
1. Follow docs in `Cli.scala` and create `Stage` and `Config` environmental variables
1. Performance can be estimated with something like 
    ```
    time { Await.result(program(InvoicesInput("someAccountId")), Inf) }
    ```

#### With Lambda

1. Get fresh Janus credentials
1. `Program.scala` contains main business logic 
1. `deployAwsLambda` will upload modified lambda package
1. In AWS Lambda console create test event with reflects `GET /invoices/{accountId}`
    ```
    {
      "pathParameters": {
        "accountId": "1234567qwerty"
      }
    }
    ```
1. Tail logs 
    ```
    export AWS_DEFAULT_REGION=eu-west-1 && awslogs get --profile membership /aws/lambda/invoicing-api-invoices-CODE --watch
    ```
   
#### With API Gateway (Postman)

1. HTTP request will have to be signed with AWS signature
1. Get fresh janus credentials
1. Paste them in `Postman | Auth | AWS Signature`
1. Don't forget also the API key `x-api-key`


## How can we measure success?

This endpoint should not be returning non-200 responses because the client is server side of manage-frontend which should always have valid credentials, and send request for invoices only for users that have paid for a product which MMA can check via members-data-api. This means failure likely represents misconfiguration, or missing implementation, so should be fixed ASAP.

## Have we considered potential risks?

- infosec has been consulted
- additional AWS signature is required for all requests on top of API key
- signed in user should not be able to request another user's invoices
- alarm on failure
