### PR TITLE
GET /invoices/{invoiceId} PDF

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,11 +8,11 @@ lazy val root = (project in file("."))
     organizationName := "The Guardian",
     scalaVersion := "2.13.3",
     libraryDependencies ++= List(
-      "org.scalaj"      %% "scalaj-http"  % "2.4.2",
-      "com.lihaoyi"     %% "upickle"      % "1.1.0",
-      "org.scalameta"   %% "munit"        % "0.7.9"   % Test,
-      "com.gu"          %% "spy"          % "0.1.1",
-      "org.scala-lang.modules" %% "scala-async" % "1.0.0-M1"
+      "org.scalaj"             %% "scalaj-http"  % "2.4.2",
+      "com.lihaoyi"            %% "upickle"      % "1.1.0",
+      "org.scalameta"          %% "munit"        % "0.7.9"   % Test,
+      "com.gu"                 %% "spy"          % "0.1.1",
+      "org.scala-lang.modules" %% "scala-async"  % "1.0.0-M1"
     ),
     testFrameworks += new TestFramework("munit.Framework"),
     assemblyJarName := "invoicing-api.jar",
@@ -30,6 +30,11 @@ lazy val deployAwsLambda = taskKey[Unit]("Directly update AWS lambda code from D
 deployAwsLambda := {
   import scala.sys.process._
   assembly.value
-  "aws lambda update-function-code --function-name invoicing-api-refund-CODE --zip-file fileb://target/scala-2.13/invoicing-api.jar --profile membership --region eu-west-1".!
-  "aws lambda update-function-code --function-name invoicing-api-invoices-CODE --zip-file fileb://target/scala-2.13/invoicing-api.jar --profile membership --region eu-west-1".!
+  List(
+    "invoicing-api-refund",
+    "invoicing-api-invoices",
+    "invoicing-api-pdf",
+  ) foreach { name =>
+    s"aws lambda update-function-code --function-name $name-CODE --zip-file fileb://target/scala-2.13/invoicing-api.jar --profile membership --region eu-west-1".!
+  }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -35,6 +35,6 @@ deployAwsLambda := {
     "invoicing-api-invoices",
     "invoicing-api-pdf",
   ) foreach { name =>
-    s"aws lambda update-function-code --function-name $name-CODE --zip-file fileb://target/scala-2.13/invoicing-api.jar --profile membership --region eu-west-1".!
+    s"aws lambda update-function-code --function-name $name-DEV --zip-file fileb://target/scala-2.13/invoicing-api.jar --profile membership --region eu-west-1".!
   }
 }

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -16,7 +16,6 @@ Conditions:
   IsProd: !Equals [!Ref "Stage", "PROD"]
 
 Resources:
-
   # ****************************************************************************
   # Alarms
   # ****************************************************************************
@@ -67,10 +66,34 @@ Resources:
     DependsOn:
       - InvoicingLambdaRole
 
+  FailedPdfAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: IsProd
+    Properties:
+      AlarmName: "URGENT 9-5 - PROD: Failed to download invoice PDF"
+      AlarmDescription: |
+        - manage-frontend user will not be able to download invoice PDF
+        - https://github.com/guardian/invoicing-api/blob/master/src/main/scala/com/gu/invoicing/pdf/README.md
+        - export AWS_DEFAULT_REGION=eu-west-1 && awslogs get --profile membership /aws/lambda/invoicing-api-pdf-PROD --start='DD/mm/yyyy HH:MM' --end='DD/mm/yyyy HH:MM'
+      AlarmActions:
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:MarioTest
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      Dimensions:
+        - Name: FunctionName
+          Value: !Ref PdfLambda
+      EvaluationPeriods: 1
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Period: 300
+      Statistic: Sum
+      Threshold: 1
+      TreatMissingData: notBreaching
+    DependsOn:
+      - InvoicingLambdaRole
+
   # ****************************************************************************
   # Lambdas
   # ****************************************************************************
-
   RefundLambda:
     Type: AWS::Lambda::Function
     Properties:

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -111,6 +111,26 @@ Resources:
     DependsOn:
       - InvoicingLambdaRole
 
+  PdfLambda:
+    Type: AWS::Lambda::Function
+    Properties:
+      Description: Download PDF invoice by invoiceId
+      FunctionName: !Sub invoicing-api-pdf-${Stage}
+      Code:
+        S3Bucket: membership-dist
+        S3Key: !Sub support/${Stage}/invoicing-api/invoicing-api.jar
+      Handler: com.gu.invoicing.pdf.Lambda::handleRequest
+      Environment:
+        Variables:
+          Stage: !Ref Stage
+          Config: !Sub '{{resolve:ssm:/invoicing-api/${Stage}/config:1}}'
+      Role: !GetAtt InvoicingLambdaRole.Arn
+      MemorySize: 3008
+      Runtime: java8
+      Timeout: 900
+    DependsOn:
+      - InvoicingLambdaRole
+
   # ****************************************************************************
   # API
   # ****************************************************************************
@@ -230,6 +250,38 @@ Resources:
       - InvoicesLambda
 
   # ****************************************************************************
+  # GET /invoices/{invoiceId}
+  # ****************************************************************************
+  PdfInvoiceIdPath:
+    Type: AWS::ApiGateway::Resource
+    Properties:
+      RestApiId: !Ref InvoicingApi
+      ParentId: !Ref InvoicesEndpoint
+      PathPart: "{invoiceId}"
+    DependsOn:
+      - InvoicingApi
+      - InvoicesEndpoint
+
+  PdfInvoiceIdPathGetMethod:
+    Type: AWS::ApiGateway::Method
+    Properties:
+      AuthorizationType: AWS_IAM
+      ApiKeyRequired: true
+      RestApiId: !Ref InvoicingApi
+      ResourceId: !Ref PdfInvoiceIdPath
+      HttpMethod: GET
+      RequestParameters:
+        method.request.path.invoiceId: true
+      Integration:
+        Type: AWS_PROXY
+        IntegrationHttpMethod: POST # this for the interaction between API Gateway and Lambda and MUST be POST
+        Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${PdfLambda.Arn}/invocations
+    DependsOn:
+      - InvoicingApi
+      - PdfLambda
+      - PdfInvoiceIdPath
+
+  # ****************************************************************************
   # Access control
   # ****************************************************************************
 
@@ -251,6 +303,15 @@ Resources:
       Principal: apigateway.amazonaws.com
     DependsOn:
       - InvoicesLambda
+
+  PdfLambdaPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:invokeFunction
+      FunctionName: !Sub invoicing-api-pdf-${Stage}
+      Principal: apigateway.amazonaws.com
+    DependsOn:
+      - PdfLambda
 
   InvoicingLambdaRole:
     Type: AWS::IAM::Role
@@ -277,6 +338,7 @@ Resources:
                 Resource:
                 - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/invoicing-api-refund-${Stage}:log-stream:*
                 - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/invoicing-api-invoices-${Stage}:log-stream:*
+                - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/invoicing-api-pdf-${Stage}:log-stream:*
 
         - PolicyName: ReadPrivateCredentials
           PolicyDocument:

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -161,7 +161,9 @@ Resources:
     Type: AWS::ApiGateway::RestApi
     Properties:
       Name: !Sub invoicing-api-${Stage}
-      Description: Zuora invoice management (refunds)
+      Description: Zuora invoice management (refunds, list invoices, download PDF)
+      BinaryMediaTypes:
+        - application/pdf
 
   InvoicingApiStage:
     Type: AWS::ApiGateway::Stage

--- a/src/main/scala/com/gu/invoicing/invoice/Model.scala
+++ b/src/main/scala/com/gu/invoicing/invoice/Model.scala
@@ -51,7 +51,6 @@ object Model extends OptionPickler {
     status: String,
     body: String,
     invoiceItems: List[InvoiceItem],
-    invoiceFiles: List[InvoiceFile],
   )
   case class InvoiceItem(
     id: String,
@@ -72,11 +71,6 @@ object Model extends OptionPickler {
     processingType: String,
     appliedToItemId: Option[String]
   )
-  case class InvoiceFile(
-    id: String,
-    versionNumber: Int,
-    pdfFileUrl: String
-  )
 
   case class InvoiceWithPayment(
     subscriptionName: String,
@@ -96,15 +90,6 @@ object Model extends OptionPickler {
       invoice: Invoice,
       paymentMethod: PaymentMethod,
     ): InvoiceWithPayment = {
-      // PDF invoice files are in reverse chronological order meaning most recent version is first
-      // https://www.zuora.com/developer/api-reference/#operation/GET_InvoiceFiles
-      val pdfPath =
-        invoice
-          .invoiceFiles
-          .headOption
-          .getOrElse(throw new AssertionError(s"PDF file should exist for each invoice: $invoice"))
-          .pdfFileUrl match { case s"/v1/files/$fileId" => s"invoices/$fileId" }
-
       // Currently we handle only invoices with single subscription, so any invoice item should do for getting the subscription name
       val subscriptionName =
         invoice
@@ -118,7 +103,7 @@ object Model extends OptionPickler {
         date = invoice.invoiceDate,
         paymentMethod = paymentMethod,
         price = invoice.amount.toDouble,
-        pdfPath = pdfPath,
+        pdfPath = s"invoices/${invoice.id}",
         invoiceId = invoice.id
       )
     }
@@ -245,7 +230,6 @@ object Model extends OptionPickler {
   implicit val invoicesRW: ReadWriter[Invoices] = macroRW
   implicit val invoiceRW: ReadWriter[Invoice] = macroRW
   implicit val invoiceItemRW: ReadWriter[InvoiceItem] = macroRW
-  implicit val invoiceFileRW: ReadWriter[InvoiceFile] = macroRW
 
   implicit val paymentRW: ReadWriter[Payment] = macroRW
   implicit val paidInvoiceRW: ReadWriter[PaidInvoice] = macroRW

--- a/src/main/scala/com/gu/invoicing/pdf/Cli.scala
+++ b/src/main/scala/com/gu/invoicing/pdf/Cli.scala
@@ -1,0 +1,21 @@
+package com.gu.invoicing.pdf
+
+import com.gu.invoicing.invoice.Log._
+import com.gu.invoicing.invoice.Model._
+import scala.util.chaining._
+import Impl._
+import Program._
+import com.gu.invoicing.pdf.Model.PdfInput
+import com.gu.spy._
+
+/**
+ * Create environmental variables with Zuora OAuth credentials:
+ *
+ *   export STAGE = CODE
+ *   export Config = { "clientId": "******", "clientSecret": "*****"}
+ */
+object Cli {
+  def main(args: Array[String]): Unit = {
+    program(PdfInput("anInvoiceId", "anIdentityId"))
+  }
+}

--- a/src/main/scala/com/gu/invoicing/pdf/Impl.scala
+++ b/src/main/scala/com/gu/invoicing/pdf/Impl.scala
@@ -9,7 +9,10 @@ object Impl {
   lazy val stage = getenv("Stage")
 
   lazy val zuoraApiHost: String =
-    stage match { case "DEV" | "CODE" => "https://rest.apisandbox.zuora.com"; case "PROD" => "https://rest.zuora.com" }
+    stage match {
+      case "DEV" | "CODE" => "https://rest.apisandbox.zuora.com"
+      case "PROD"         => "https://rest.zuora.com"
+    }
 
   lazy val config = read[Config](getenv("Config"))
 

--- a/src/main/scala/com/gu/invoicing/pdf/Impl.scala
+++ b/src/main/scala/com/gu/invoicing/pdf/Impl.scala
@@ -41,4 +41,10 @@ object Impl {
       .pipe(read[Account](_))
       .basicInfo
       .IdentityId__c
+
+  val noCache = Map( // https://stackoverflow.com/a/2068407/5205022
+    "Cache-Control" -> "no-cache, no-store, must-revalidate",
+    "Pragma" -> "no-cache",
+    "Expires" -> "0"
+  )
 }

--- a/src/main/scala/com/gu/invoicing/pdf/Impl.scala
+++ b/src/main/scala/com/gu/invoicing/pdf/Impl.scala
@@ -1,0 +1,44 @@
+package com.gu.invoicing.pdf
+
+import java.lang.System.getenv
+import com.gu.invoicing.pdf.Model._
+import scalaj.http.Http
+import scala.util.chaining._
+
+object Impl {
+  lazy val stage = getenv("Stage")
+
+  lazy val zuoraApiHost: String =
+    stage match { case "DEV" | "CODE" => "https://rest.apisandbox.zuora.com"; case "PROD" => "https://rest.zuora.com" }
+
+  lazy val config = read[Config](getenv("Config"))
+
+  lazy val accessToken: String = {
+    Http(s"$zuoraApiHost/oauth/token")
+      .postForm(Seq(
+        "client_id" -> config.clientId,
+        "client_secret" -> config.clientSecret,
+        "grant_type" -> "client_credentials"
+      ))
+      .asString
+      .body
+      .pipe(read[AccessToken](_))
+      .access_token
+  }
+
+  def getInvoice(invoiceId: String): Invoice =
+    Http(s"$zuoraApiHost/v1/object/invoice/$invoiceId")
+      .header("Authorization", s"Bearer ${accessToken}")
+      .asString
+      .body
+      .pipe(read[Invoice](_))
+
+  def getIdentityId(accountId: String): String =
+    Http(s"$zuoraApiHost/v1/accounts/$accountId")
+      .header("Authorization", s"Bearer ${accessToken}")
+      .asString
+      .body
+      .pipe(read[Account](_))
+      .basicInfo
+      .IdentityId__c
+}

--- a/src/main/scala/com/gu/invoicing/pdf/Lambda.scala
+++ b/src/main/scala/com/gu/invoicing/pdf/Lambda.scala
@@ -5,6 +5,7 @@ import java.util.Base64
 
 import com.gu.invoicing.pdf.Log._
 import com.gu.invoicing.pdf.Model._
+import com.gu.invoicing.pdf.Impl._
 import com.gu.invoicing.pdf.Program._
 
 import scala.concurrent.Await
@@ -30,7 +31,7 @@ object Lambda {
       .pipe { PdfInput.apply }
       .tap  { info[PdfInput] }
       .pipe { program }
-      .pipe { ApiGatewayOutput(200, _, true, Map("Content-Type" -> "application/pdf;charset=UTF-8")) }
+      .pipe { ApiGatewayOutput(200, _, true, Map("Content-Type" -> "application/pdf;charset=UTF-8") ++ noCache ) }
       .pipe { write(_) }
       .pipe { _.getBytes }
       .pipe { output.write }

--- a/src/main/scala/com/gu/invoicing/pdf/Lambda.scala
+++ b/src/main/scala/com/gu/invoicing/pdf/Lambda.scala
@@ -1,0 +1,37 @@
+package com.gu.invoicing.pdf
+
+import java.io.{InputStream, OutputStream}
+import java.util.Base64
+
+import com.gu.invoicing.pdf.Log._
+import com.gu.invoicing.pdf.Model._
+import com.gu.invoicing.pdf.Program._
+
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration.Inf
+import scala.util.chaining._
+import com.gu.spy._
+
+/**
+ * Example test event for running the lambda from AWS Console
+ * {
+ *   "headers": {
+ *     "x-identity-id": "1000001"
+ *   },
+ *   "pathParameters": {
+ *     "invoiceId": "1a2s3d4f5g6h7j8k"
+ *   }
+ * }
+ */
+object Lambda {
+  def handleRequest(input: InputStream, output: OutputStream): Unit =
+    input
+      .pipe { read[ApiGatewayInput](_) }
+      .pipe { PdfInput.apply }
+      .tap  { info[PdfInput] }
+      .pipe { program }
+      .pipe { ApiGatewayOutput(200, _, true, Map("Content-Type" -> "application/pdf;charset=UTF-8")) }
+      .pipe { write(_) }
+      .pipe { _.getBytes }
+      .pipe { output.write }
+}

--- a/src/main/scala/com/gu/invoicing/pdf/Log.scala
+++ b/src/main/scala/com/gu/invoicing/pdf/Log.scala
@@ -1,0 +1,18 @@
+package com.gu.invoicing.pdf
+
+import com.gu.invoicing.pdf.Model._
+
+/**
+ * Log deserialised JSON objects.
+ */
+object Log extends {
+  def info[P <: Product : Writer](p: P): Unit = info(write(p))
+  def warn[P <: Product : Writer](p: P): Unit = warn(write(p))
+  def error[P <: Product : Writer](p: P): Unit = error(write(p))
+
+  private val logger = java.util.logging.Logger.getGlobal
+  private object ErrorLevel extends java.util.logging.Level("ERROR", 950)
+  private def info(s: String): Unit = logger.info(s)
+  private def warn(s: String): Unit = logger.warning(s)
+  private def error(s: String): Unit = logger.log(ErrorLevel, s)
+}

--- a/src/main/scala/com/gu/invoicing/pdf/Model.scala
+++ b/src/main/scala/com/gu/invoicing/pdf/Model.scala
@@ -58,6 +58,7 @@ object Model extends OptionPickler {
   /**
    * https://docs.aws.amazon.com/apigateway/latest/developerguide/lambda-proxy-binary-media.html
    * https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-payload-encodings-configure-with-console.html
+   * https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-restapi.html#cfn-apigateway-restapi-binarymediatypes
    *
    * {
    *   "status": 200,

--- a/src/main/scala/com/gu/invoicing/pdf/Model.scala
+++ b/src/main/scala/com/gu/invoicing/pdf/Model.scala
@@ -1,0 +1,82 @@
+package com.gu.invoicing.pdf
+
+/**
+ * Needed for upickle to handle optional fields
+ * http://www.lihaoyi.com/upickle/#CustomConfiguration
+ */
+class OptionPickler extends upickle.AttributeTagged {
+  implicit def optionWriter[T: Writer]: Writer[Option[T]] =
+    implicitly[Writer[T]].comap[Option[T]] {
+      case None => null.asInstanceOf[T]
+      case Some(x) => x
+    }
+
+  implicit def optionReader[T: Reader]: Reader[Option[T]] = {
+    new Reader.Delegate[Any, Option[T]](implicitly[Reader[T]].map(Some(_))){
+      override def visitNull(index: Int) = None
+    }
+  }
+}
+
+object Model extends OptionPickler {
+  case class Config(clientId: String, clientSecret: String)
+  case class AccessToken(access_token: String)
+
+  case class Invoice(
+    AccountId: String,
+    Body: String /* Base64 encoded PDF */
+  )
+  case class BasicInfo(IdentityId__c: String)
+  case class Account(basicInfo: BasicInfo)
+  case class InvoiceFile(pdfFileUrl: String)
+  case class InvoiceFiles(invoiceFiles: List[InvoiceFile])
+
+  implicit val configRW: ReadWriter[Config] = macroRW
+  implicit val accessTokenRW: ReadWriter[AccessToken] = macroRW
+  implicit val invoiceRW: ReadWriter[Invoice] = macroRW
+  implicit val BasicInfoRW: ReadWriter[BasicInfo] = macroRW
+  implicit val AccountRW: ReadWriter[Account] = macroRW
+  implicit val InvoiceFileRW: ReadWriter[InvoiceFile] = macroRW
+  implicit val InvoiceFileIdsRW: ReadWriter[InvoiceFiles] = macroRW
+
+  // https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-input-format
+  case class InvoiceId(invoiceId: String)
+  case class ApiGatewayInput(
+    pathParameters: InvoiceId,
+    headers: Map[String, String]
+  )
+  case class PdfInput(invoiceId: String, identityId: String)
+  object PdfInput {
+    def apply(apiGatewayInput: ApiGatewayInput): PdfInput = {
+      new PdfInput(
+        apiGatewayInput.pathParameters.invoiceId,
+        apiGatewayInput.headers.getOrElse("x-identity-id", throw new Error("x-identity-id header should be provided")),
+      )
+    }
+  }
+
+  /**
+   * https://docs.aws.amazon.com/apigateway/latest/developerguide/lambda-proxy-binary-media.html
+   * https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-payload-encodings-configure-with-console.html
+   *
+   * {
+   *   "status": 200,
+   *   "body": "base64EncodedByteArray",
+   *   "isBase64Encoded":true,
+   *   "headers": {
+   *     "Content-Type":"application/pdf;charset=UTF-8"
+   *   }
+   * }
+   */
+  case class ApiGatewayOutput(
+    statusCode: Int,
+    body: String, // base64 encoded byte array representing PDF
+    isBase64Encoded: Boolean,
+    headers: Map[String, String]
+  )
+
+  implicit val InvoiceIdRW: ReadWriter[InvoiceId] = macroRW
+  implicit val awsBodyRW: ReadWriter[ApiGatewayInput] = macroRW
+  implicit val apiGatewayOutputRW: ReadWriter[ApiGatewayOutput] = macroRW
+  implicit val PdfInputRW: ReadWriter[PdfInput] = macroRW
+}

--- a/src/main/scala/com/gu/invoicing/pdf/Program.scala
+++ b/src/main/scala/com/gu/invoicing/pdf/Program.scala
@@ -1,0 +1,14 @@
+package com.gu.invoicing.pdf
+
+import com.gu.invoicing.pdf.Model._
+import com.gu.invoicing.pdf.Impl._
+
+object Program { /** Main business logic */
+  def program(input: PdfInput): String = {
+    val PdfInput(invoiceId, identityId) = input
+    val Invoice(accountId, pdf) = getInvoice(invoiceId)
+    val actualIdentityId = getIdentityId(accountId)
+    assert(identityId == actualIdentityId, s"Requested invoice should NOT belong to different identity $actualIdentityId")
+    pdf
+  }
+}

--- a/src/main/scala/com/gu/invoicing/pdf/README.md
+++ b/src/main/scala/com/gu/invoicing/pdf/README.md
@@ -63,3 +63,9 @@ Content-Type: application/pdf;charset=UTF-8
 1. Get fresh janus credentials
 1. Paste them in `Postman | Auth | AWS Signature`
 1. Don't forget also the API key `x-api-key`
+
+### Configure PDF binary response in API Gateway
+
+1. Add `application/pdf` under `Settings | Binary Media Types` and then re-deploy the API.
+1. https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-payload-encodings-configure-with-console.html
+1. https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-restapi.html#cfn-apigateway-restapi-binarymediatypes

--- a/src/main/scala/com/gu/invoicing/pdf/README.md
+++ b/src/main/scala/com/gu/invoicing/pdf/README.md
@@ -1,0 +1,65 @@
+## Get invoice PDF by invoiceId
+
+The endpoint is secured with 
+- API key
+- AWS Signature
+- Validation that invoice belongs to identity that requests it 
+
+**Request:**
+
+```
+GET /invoices/{invoiceId}
+Host: https://{apiGatewayId}.execute-api.{region}.amazonaws.com/{STAGE}
+x-identity-id
+x-api-key: ********
+X-Amz-Security-Token: ******** 
+X-Amz-Date: ********
+Authorization: ******** 
+```
+
+**Response:**
+
+Base64 encoded PDF:
+
+```
+Content-Type: application/pdf;charset=UTF-8
+```
+
+### How to test in CODE
+
+#### With CLI 
+
+1. Get invoicing-api+uat@guardian.co.uk Zuora OAuth client credentials
+1. Follow docs in `Cli.scala` and create `Stage` and `Config` environmental variables
+1. Simply run something like
+    ```
+    program(PdfInput("anInvoiceId", "anIdentityId"))
+    ```
+
+#### With Lambda
+
+1. Get fresh Janus credentials
+1. `Program.scala` contains main business logic 
+1. `deployAwsLambda` will upload modified lambda package
+1. In AWS Lambda console create test event that reflects `GET /invoices/{invoiceId}`
+    ```
+    {
+      "headers": {
+        "x-identity-id": "1000001"
+      },
+      "pathParameters": {
+        "invoiceId": "1a2s3d4f5g6h7j8k"
+      }
+    }
+    ```
+1. Tail logs 
+    ```
+    export AWS_DEFAULT_REGION=eu-west-1 && awslogs get --profile membership /aws/lambda/invoicing-api-pdf-CODE --watch
+    ```
+   
+#### With API Gateway (Postman)
+
+1. HTTP request will have to be signed with AWS signature
+1. Get fresh janus credentials
+1. Paste them in `Postman | Auth | AWS Signature`
+1. Don't forget also the API key `x-api-key`


### PR DESCRIPTION
## What does this change?

* https://trello.com/c/ggqXe1rg/1492-goal-expose-invoices-for-the-billing-tab
* Related PR: https://github.com/guardian/invoicing-api/pull/7
* If signed in user clicks on invoice PDF link in manage-frontend, then invoicing-api responds with `application/pdf`
* Main business logic is in `Program.scala`
* Note this also changes `GET /invoices` response to `"pdfPath": "anInvoiceId"`  instead of `"pdfPath": "aFileId"`

## How to test?

See `com.gu.invoicing/pdf/README.md`

## Have we considered potential risks?

- Besides required secrets, invoicing-api will perform validation against that the requested invoice belongs to the requesting identity, by independently retrieving `identityId` from `invoiceId` and checking against `x-identity-id` header added by server-side of manage-frontend.
- Alarm on any error
