### PR TITLE
Support invoices with multiple subscriptions

### DIFF
--- a/src/main/scala/com/gu/invoicing/invoice/Impl.scala
+++ b/src/main/scala/com/gu/invoicing/invoice/Impl.scala
@@ -148,6 +148,18 @@ object Impl {
     }
   }
 
+  /**
+   * Currently we can handle invoices that have only one Subscriptions, so make sure
+   * all the invoice items have the same subscriptionId field, and return on of them
+   */
+  def tmp(invoices: List[Invoice]): List[Invoice] = {
+    invoices.flatMap { invoice =>
+      invoice.invoiceItems.groupBy(_.subscriptionName).keys.toList.map{ subName =>
+        invoice.copy(invoiceItems = List[InvoiceItem](InvoiceItem(subName)))
+      }
+    }
+  }
+
   def transformToMmaExpectedFormat(
     invoicesWithPayment: List[InvoiceWithPayment]
   ): List[MmaInvoiceWithPayment] = {

--- a/src/main/scala/com/gu/invoicing/invoice/Model.scala
+++ b/src/main/scala/com/gu/invoicing/invoice/Model.scala
@@ -69,7 +69,8 @@ object Model extends JsonSupport {
     price: Double,
     paymentMethod: String,
     last4: Option[String] = None, // for card and direct debit
-    cardType: Option[String] = None // Visa, MasterCard
+    cardType: Option[String] = None, // Visa, MasterCard
+    hasMultipleSubs: Boolean // to handle edge case of multiple subscriptions within a single invoice
   )
 
   object MmaInvoiceWithPayment {
@@ -80,7 +81,8 @@ object Model extends JsonSupport {
         date = invoiceWithPayment.date,
         pdfPath = invoiceWithPayment.pdfPath,
         price = invoiceWithPayment.price,
-        paymentMethod = invoiceWithPayment.paymentMethod.Type
+        paymentMethod = invoiceWithPayment.paymentMethod.Type,
+        hasMultipleSubs = false
       )
 
       val paymentMethod = invoiceWithPayment.paymentMethod

--- a/src/main/scala/com/gu/invoicing/invoice/Program.scala
+++ b/src/main/scala/com/gu/invoicing/invoice/Program.scala
@@ -29,10 +29,11 @@ object Program { /** Main business logic */
     val positiveInvoices       = await(invoicesF)
     val payments               = await(paymentsF)
     val paymentMethods         = await(paymentMethodsF)
-    val lalala                      = tmp(positiveInvoices)
-    val invoicesWithPayment    = joinInvoicesWithPayment(lalala, payments, paymentMethods)
+    val invoices               = supportInvoicesWithMultipleSubscriptions(positiveInvoices)
+    val invoicesWithPayment    = joinInvoicesWithPayment(invoices, payments, paymentMethods)
     val mmaInvoicesWithPayment = transformToMmaExpectedFormat(invoicesWithPayment)
-    mmaInvoicesWithPayment
+    val multiSubTaggedInvoices = tagMultiSubInvoices(mmaInvoicesWithPayment)
+    multiSubTaggedInvoices
   }
 }
 

--- a/src/main/scala/com/gu/invoicing/invoice/Program.scala
+++ b/src/main/scala/com/gu/invoicing/invoice/Program.scala
@@ -29,8 +29,8 @@ object Program { /** Main business logic */
     val positiveInvoices       = await(invoicesF)
     val payments               = await(paymentsF)
     val paymentMethods         = await(paymentMethodsF)
-    val _                      = allInvoicesShouldHaveASingleSubscription(positiveInvoices)
-    val invoicesWithPayment    = joinInvoicesWithPayment(positiveInvoices, payments, paymentMethods)
+    val lalala                      = tmp(positiveInvoices)
+    val invoicesWithPayment    = joinInvoicesWithPayment(lalala, payments, paymentMethods)
     val mmaInvoicesWithPayment = transformToMmaExpectedFormat(invoicesWithPayment)
     mmaInvoicesWithPayment
   }


### PR DESCRIPTION
## What does this change?

```
   * ... handle the rare edge case of user being invoiced for
   * multiple subscriptions in a single invoice. Such invoices have a single price,
   * however MMA design displays invoices grouped by product. This happens in the following cases:
   *   - customer has been through a conversation with a CSR on the phone who would have explained that there would be a product transition in their next bill; or
   *   - it's a result of some kind of manual account for a special reason (e.g. GW agent)
   *
```

Response contains `hasMultipleSubs` flag

```
        {
            "invoiceId": "123456789",
            "subscriptionName": "A-S00000003",
            "date": "2020-06-04",
            "pdfPath": "invoices/123456789",
            "price": 59.49,
            "paymentMethod": "PayPal",
            "hasMultipleSubs": true
        },
        {
            "invoiceId": "123456789",
            "subscriptionName": "A-S00000002",
            "date": "2020-06-04",
            "pdfPath": "invoices/123456789",
            "price": 59.49,
            "paymentMethod": "PayPal",
            "hasMultipleSubs": true
        },
        {
            "invoiceId": "98765431",
            "subscriptionName": "A-S00000001",
            "date": "2020-06-20",
            "pdfPath": "invoices/98765431",
            "price": 12.57,
            "paymentMethod": "DirectDebit",
            "last4": "9911",
            "hasMultipleSubs": false
        }
```

## How to test

```
   * This scenario can be simulated/tested by
   *   1. find existing account in Zuora
   *   2. create multiple subscriptions via 'create new subscription' button with same contract/acceptance date
   *   3. bill run with acceptance date
   *   4. post invoices
   *   5. process payment
   */
```

## How can we measure success?

??

## Have we considered potential risks?

- very low frequency edge case
- confusing edge case whose understanding requires highly specific institutional knowledge
- hacky implementation increasing un-maintainability

## Images

![image](https://user-images.githubusercontent.com/13835317/90921796-c8d90000-e3e2-11ea-9a47-0702560508e8.png)
