### PR TITLE
Refresh Zuora access token periodically

### DIFF
--- a/src/main/scala/com/gu/invoicing/common/ZuoraAuth.scala
+++ b/src/main/scala/com/gu/invoicing/common/ZuoraAuth.scala
@@ -1,6 +1,8 @@
 package com.gu.invoicing.common
 
 import java.lang.System.getenv
+import java.util.{Timer, TimerTask}
+
 import scala.util.chaining._
 import scalaj.http.Http
 
@@ -19,7 +21,14 @@ object ZuoraAuth extends JsonSupport {
       case "PROD" => "https://rest.zuora.com"
     }
 
-  lazy val accessToken: String = {
+  /**
+   * Because list invoices is hit frequently JVM is kept warm and val access token
+   * would seem to persist across lambda executions which meant the token would expire
+   * after one hour and because it was val it would not be requested again. Hence now
+   * we periodically refreshes the token (making it def would have performance penalty)
+   */
+  var accessToken: String = _
+  private def getAccessToken(): String = {
     Http(s"$zuoraApiHost/oauth/token")
       .postForm(Seq(
         "client_id" -> config.clientId,
@@ -31,4 +40,10 @@ object ZuoraAuth extends JsonSupport {
       .pipe(read[AccessToken](_))
       .access_token
   }
+  private val timer = new Timer()
+  timer.schedule(
+    new TimerTask { def run(): Unit = accessToken = getAccessToken() },
+    0, 5 * 60 * 1000 // refresh token every 5 min
+  )
+  accessToken = getAccessToken() // set token on initialization
 }


### PR DESCRIPTION
## What does this change?

List invoices endpoint is hit frequently which seems to keep lambda container and JVM warm long enough to be re-used for the next invocation. It seem to keep it warm long enough for the Zuora access token to expire after one hour. Because previously access token was `val` it would not get a new one. 

![image](https://user-images.githubusercontent.com/13835317/91308873-cd693400-e7a7-11ea-9529-879c4039a053.png)

List invoices is hit so frequently because even if user does not have paid product, manage-frontend makes the request (which then returns empty list). Ideally manage-frontend would not make this call unnecessarily.

## How to test

```
export AWS_DEFAULT_REGION=eu-west-1 && awslogs get --profile membership /aws/lambda/invoicing-api-invoices-PROD --watch
```