### PR TITLE
Retry Zuora authentication

### DIFF
--- a/src/main/scala/com/gu/invoicing/common/Retry.scala
+++ b/src/main/scala/com/gu/invoicing/common/Retry.scala
@@ -1,0 +1,15 @@
+package com.gu.invoicing.common
+
+import scala.annotation.tailrec
+import scala.util.{Failure, Try}
+
+object Retry { // https://stackoverflow.com/a/7931459/5205022
+  @tailrec
+  def retry[T](n: Int)(fn: => T): Try[T] = {
+    Try { fn } match {
+      case Failure(_) if n > 1 => retry(n - 1)(fn)
+      case fn => fn
+    }
+  }
+  def retry[T](fn: => T): Try[T] = retry(2)(fn)
+}


### PR DESCRIPTION
## What does this change?

* Related https://github.com/guardian/invoicing-api/pull/16
* Handle temporary outages by not updating token cache. Token expires after one hour but we refresh every 5 minutes so reusing previous one should be ok.

## Have we considered potential risks?

Because of outages such as https://trust.zuora.com/incidents/76mw16rl3qrk
