### PR TITLE
GET /next-invoice-date/{subscriptionName}

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,12 +8,13 @@ lazy val root = (project in file("."))
     organizationName := "The Guardian",
     scalaVersion := "2.13.3",
     libraryDependencies ++= List(
+      "org.scalameta"          %% "munit"        % "0.7.14"   % Test,
       "org.scalaj"             %% "scalaj-http"  % "2.4.2",
       "com.lihaoyi"            %% "upickle"      % "1.1.0",
-      "org.scalameta"          %% "munit"        % "0.7.9"   % Test,
       "com.gu"                 %% "spy"          % "0.1.1",
-      "org.scala-lang.modules" %% "scala-async"  % "1.0.0-M1"
-    ),
+      "org.scala-lang.modules" %% "scala-async"  % "1.0.0-M1",
+      "com.lihaoyi"            %% "pprint"       % "0.6.0",
+),
     testFrameworks += new TestFramework("munit.Framework"),
     assemblyJarName := "invoicing-api.jar",
     riffRaffPackageType := assembly.value,
@@ -36,6 +37,7 @@ deployAwsLambda := {
     "invoicing-api-refund",
     "invoicing-api-invoices",
     "invoicing-api-pdf",
+    "invoicing-api-nextinvoicedate",
   ) foreach { name =>
     s"aws lambda update-function-code --function-name $name-$stage --zip-file fileb://target/scala-2.13/invoicing-api.jar --profile membership --region eu-west-1".!
   }

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: "2010-09-09"
 
-Description: Zuora invoice management such as refunds, downloading PDF invoices
+Description: Zuora invoice management such as refunds, downloading PDF invoices, next invoice date
 
 Parameters:
   Stage:
@@ -91,6 +91,31 @@ Resources:
     DependsOn:
       - InvoicingLambdaRole
 
+  NextInvoiceDateAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: IsProd
+    Properties:
+      AlarmName: "URGENT 9-5 - PROD: Failed to determine next invoice date"
+      AlarmDescription: |
+        - At least holiday or delivery problem credit processor will not be able to determine when to apply the credit
+        - https://github.com/guardian/invoicing-api/blob/master/src/main/scala/com/gu/invoicing/nextinvoicedate/README.md
+        - export AWS_DEFAULT_REGION=eu-west-1 && awslogs get --profile membership /aws/lambda/invoicing-api-nextinvoicedate-PROD --start='DD/mm/yyyy HH:MM' --end='DD/mm/yyyy HH:MM'
+      AlarmActions:
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:MarioTest
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      Dimensions:
+        - Name: FunctionName
+          Value: !Ref NextInvoiceDateLambda
+      EvaluationPeriods: 1
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Period: 300
+      Statistic: Sum
+      Threshold: 1
+      TreatMissingData: notBreaching
+    DependsOn:
+      - InvoicingLambdaRole
+
   # ****************************************************************************
   # Lambdas
   # ****************************************************************************
@@ -143,6 +168,26 @@ Resources:
         S3Bucket: membership-dist
         S3Key: !Sub support/${Stage}/invoicing-api/invoicing-api.jar
       Handler: com.gu.invoicing.pdf.Lambda::handleRequest
+      Environment:
+        Variables:
+          Stage: !Ref Stage
+          Config: !Sub '{{resolve:ssm:/invoicing-api/${Stage}/config:1}}'
+      Role: !GetAtt InvoicingLambdaRole.Arn
+      MemorySize: 3008
+      Runtime: java8
+      Timeout: 900
+    DependsOn:
+      - InvoicingLambdaRole
+
+  NextInvoiceDateLambda:
+    Type: AWS::Lambda::Function
+    Properties:
+      Description: Get next invoice date (day after last invoice period)
+      FunctionName: !Sub invoicing-api-nextinvoicedate-${Stage}
+      Code:
+        S3Bucket: membership-dist
+        S3Key: !Sub support/${Stage}/invoicing-api/invoicing-api.jar
+      Handler: com.gu.invoicing.nextinvoicedate.Lambda::handleRequest
       Environment:
         Variables:
           Stage: !Ref Stage
@@ -307,6 +352,48 @@ Resources:
       - PdfInvoiceIdPath
 
   # ****************************************************************************
+  # GET /next-invoice-date/{subscriptionName}
+  # ****************************************************************************
+  NextInvoiceDateEndpoint: # /next-invoice-date path
+    Type: AWS::ApiGateway::Resource
+    Properties:
+      RestApiId: !Ref InvoicingApi
+      ParentId: !GetAtt InvoicingApi.RootResourceId
+      PathPart: next-invoice-date
+    DependsOn:
+      - InvoicingApi
+
+  NextInvoiceDatePath: # {subscriptionName} path parameter
+    Type: AWS::ApiGateway::Resource
+    Properties:
+      RestApiId: !Ref InvoicingApi
+      ParentId: !Ref NextInvoiceDateEndpoint
+      PathPart: "{subscriptionName}"
+    DependsOn:
+      - InvoicingApi
+      - NextInvoiceDateEndpoint
+
+  NextInvoiceDatePathGetMethod: # GET verb
+    Type: AWS::ApiGateway::Method
+    Properties:
+      AuthorizationType: NONE
+      ApiKeyRequired: true
+      RestApiId: !Ref InvoicingApi
+      ResourceId: !Ref NextInvoiceDatePath
+      HttpMethod: GET
+      RequestParameters:
+        method.request.path.subscriptionName: true
+      Integration:
+        Type: AWS_PROXY
+        IntegrationHttpMethod: POST # this for the interaction between API Gateway and Lambda and MUST be POST
+        Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${NextInvoiceDateLambda.Arn}/invocations
+    DependsOn:
+      - InvoicingApi
+      - NextInvoiceDateLambda
+      - NextInvoiceDateEndpoint
+      - NextInvoiceDatePath
+
+  # ****************************************************************************
   # Access control
   # ****************************************************************************
 
@@ -338,6 +425,15 @@ Resources:
     DependsOn:
       - PdfLambda
 
+  NextInvoiceDateLambdaPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:invokeFunction
+      FunctionName: !Sub invoicing-api-nextinvoicedate-${Stage}
+      Principal: apigateway.amazonaws.com
+    DependsOn:
+      - NextInvoiceDateLambda
+
   InvoicingLambdaRole:
     Type: AWS::IAM::Role
     Properties:
@@ -364,6 +460,7 @@ Resources:
                 - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/invoicing-api-refund-${Stage}:log-stream:*
                 - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/invoicing-api-invoices-${Stage}:log-stream:*
                 - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/invoicing-api-pdf-${Stage}:log-stream:*
+                - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/invoicing-api-nextinvoicedate-${Stage}:log-stream:*
 
         - PolicyName: ReadPrivateCredentials
           PolicyDocument:

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -18,4 +18,5 @@ deployments:
         - invoicing-api-refund-
         - invoicing-api-invoices-
         - invoicing-api-pdf-
+        - invoicing-api-nextinvoicedate-
     dependencies: [cfn]

--- a/src/main/scala/com/gu/invoicing/nextinvoicedate/Cli.scala
+++ b/src/main/scala/com/gu/invoicing/nextinvoicedate/Cli.scala
@@ -1,0 +1,19 @@
+package com.gu.invoicing.nextinvoicedate
+
+import scala.util.chaining._
+import Impl._
+import Program._
+import com.gu.invoicing.nextinvoicedate.Model._
+import com.gu.spy._
+
+/**
+ * Create environmental variables with Zuora OAuth credentials:
+ *
+ *   export STAGE = CODE
+ *   export Config = { "clientId": "******", "clientSecret": "*****"}
+ */
+object Cli {
+  def main(args: Array[String]): Unit = {
+    program(NextInvoiceDateInput("A-S00000000"))
+  }
+}

--- a/src/main/scala/com/gu/invoicing/nextinvoicedate/Impl.scala
+++ b/src/main/scala/com/gu/invoicing/nextinvoicedate/Impl.scala
@@ -24,7 +24,7 @@ object Impl {
         s"""
           |{
           |    "accountId": "$accountId",
-          |    "targetDate": "${LocalDate.now.plusYears(1)}",
+          |    "targetDate": "${LocalDate.now.plusMonths(13)}",
           |    "assumeRenewal": "All"
           |}
           |""".stripMargin

--- a/src/main/scala/com/gu/invoicing/nextinvoicedate/Impl.scala
+++ b/src/main/scala/com/gu/invoicing/nextinvoicedate/Impl.scala
@@ -41,9 +41,12 @@ object Impl {
     invoiceItems: List[InvoiceItem]
   ): List[InvoiceItem] = {
     invoiceItems
+      .iterator
       .filter(_.subscriptionName == subscriptionName)
+      .filterNot(_.productName == "Discounts")
       .filterNot(_.chargeAmount < 0.0)
       .filterNot(v => v.serviceStartDate == v.serviceEndDate)
+      .toList
       .sortBy(_.serviceStartDate)
   }
 

--- a/src/main/scala/com/gu/invoicing/nextinvoicedate/Impl.scala
+++ b/src/main/scala/com/gu/invoicing/nextinvoicedate/Impl.scala
@@ -1,0 +1,62 @@
+package com.gu.invoicing.nextinvoicedate
+
+import java.time.LocalDate
+import com.gu.invoicing.common.ZuoraAuth.{accessToken, zuoraApiHost}
+import com.gu.invoicing.nextinvoicedate.Model._
+import scalaj.http.Http
+import scala.util.chaining._
+import pprint._
+
+object Impl {
+  def getAccountId(name: String): String = {
+    Http(s"$zuoraApiHost/v1/subscriptions/$name")
+      .header("Authorization", s"Bearer $accessToken")
+      .asString
+      .body
+      .pipe(read[Subscription](_))
+      .accountId
+  }
+  def getBillingPreview(accountId: String): List[InvoiceItem] = {
+    Http(s"$zuoraApiHost/v1/operations/billing-preview")
+      .header("Authorization", s"Bearer $accessToken")
+      .header("Content-Type", "application/json")
+      .postData(
+        s"""
+          |{
+          |    "accountId": "$accountId",
+          |    "targetDate": "${LocalDate.now.plusYears(1)}",
+          |    "assumeRenewal": "All"
+          |}
+          |""".stripMargin
+      )
+      .method("POST")
+      .asString
+      .body
+      .pipe(read[BillingPreview](_))
+      .invoiceItems
+  }
+
+  def collectRelevantInvoiceItems(
+    subscriptionName: String,
+    invoiceItems: List[InvoiceItem]
+  ): List[InvoiceItem] = {
+    invoiceItems
+      .filter(_.subscriptionName == subscriptionName)
+      .filterNot(_.chargeAmount < 0.0)
+      .filterNot(v => v.serviceStartDate == v.serviceEndDate)
+      .sortBy(_.serviceStartDate)
+  }
+
+  def findNextInvoiceDate(
+    items: List[InvoiceItem],
+    today: LocalDate = LocalDate.now()
+  ): Option[LocalDate] = {
+    items
+      .sliding(2, 2)
+      .collectFirst { case List(current, next) if isActiveInvoicedPeriod(current, today) => next }
+      .map(_.serviceStartDate)
+  }
+
+  private def isActiveInvoicedPeriod(item: InvoiceItem, today: LocalDate): Boolean =
+    today.isBefore(item.serviceEndDate) || today.isEqual(item.serviceEndDate)
+}

--- a/src/main/scala/com/gu/invoicing/nextinvoicedate/Impl.scala
+++ b/src/main/scala/com/gu/invoicing/nextinvoicedate/Impl.scala
@@ -25,7 +25,7 @@ object Impl {
           |{
           |    "accountId": "$accountId",
           |    "targetDate": "${LocalDate.now.plusMonths(13)}",
-          |    "assumeRenewal": "All"
+          |    "assumeRenewal": "Autorenew"
           |}
           |""".stripMargin
       )

--- a/src/main/scala/com/gu/invoicing/nextinvoicedate/Lambda.scala
+++ b/src/main/scala/com/gu/invoicing/nextinvoicedate/Lambda.scala
@@ -1,0 +1,30 @@
+package com.gu.invoicing.nextinvoicedate
+
+import java.io.{InputStream, OutputStream}
+import com.gu.invoicing.nextinvoicedate.Model._
+import com.gu.invoicing.nextinvoicedate.Impl._
+import com.gu.invoicing.nextinvoicedate.Program._
+import scala.util.chaining._
+import com.gu.spy._
+
+/**
+ * Example test event for running the lambda from AWS Console
+ * {
+ *   "pathParameters": {
+ *     "subscriptionNumber": "A-S00000000"
+ *   }
+ * }
+ */
+object Lambda {
+  def handleRequest(input: InputStream, output: OutputStream): Unit =
+    input
+      .pipe { read[ApiGatewayInput](_) }
+      .pipe { NextInvoiceDateInput.apply }
+      .tap  { info[NextInvoiceDateInput] }
+      .pipe { program }
+      .tap  { info[NextInvoiceDateOutput] }
+      .pipe { invoiceDateOutput => ApiGatewayOutput(200, write(invoiceDateOutput)) }
+      .pipe { write(_) }
+      .pipe { _.getBytes }
+      .pipe { output.write }
+}

--- a/src/main/scala/com/gu/invoicing/nextinvoicedate/Model.scala
+++ b/src/main/scala/com/gu/invoicing/nextinvoicedate/Model.scala
@@ -15,6 +15,7 @@ object Model extends JsonSupport {
     serviceStartDate: LocalDate,
     serviceEndDate: LocalDate,
     chargeAmount: Double,
+    productName: String,
   )
 
   case class BillingPreview(

--- a/src/main/scala/com/gu/invoicing/nextinvoicedate/Model.scala
+++ b/src/main/scala/com/gu/invoicing/nextinvoicedate/Model.scala
@@ -1,0 +1,50 @@
+package com.gu.invoicing.nextinvoicedate
+
+import java.time.LocalDate
+import com.gu.invoicing.common.JsonSupport
+
+object Model extends JsonSupport {
+  case class Config(clientId: String, clientSecret: String)
+  case class AccessToken(access_token: String)
+
+  case class Subscription(accountId: String)
+
+  case class InvoiceItem(
+    id: String,
+    subscriptionName: String,
+    serviceStartDate: LocalDate,
+    serviceEndDate: LocalDate,
+    chargeAmount: Double,
+  )
+
+  case class BillingPreview(
+    accountId: String,
+    invoiceItems: List[InvoiceItem],
+  )
+
+  implicit val subscription: ReadWriter[Subscription] = macroRW
+  implicit val invoiceItem: ReadWriter[InvoiceItem] = macroRW
+  implicit val billingPreview: ReadWriter[BillingPreview] = macroRW
+
+  case class SubscriptionName(subscriptionName: String)
+  case class ApiGatewayInput(
+    pathParameters: SubscriptionName,
+    headers: Map[String, String]
+  )
+  case class NextInvoiceDateInput(subscriptionName: String)
+  object NextInvoiceDateInput {
+    def apply(apiGatewayInput: ApiGatewayInput): NextInvoiceDateInput =
+      NextInvoiceDateInput(apiGatewayInput.pathParameters.subscriptionName)
+  }
+  case class NextInvoiceDateOutput(nextInvoiceDate: Option[LocalDate] = None)
+  case class ApiGatewayOutput(
+    statusCode: Int,
+    body: String,
+  )
+
+  implicit val subscriptionNumber: ReadWriter[SubscriptionName] = macroRW
+  implicit val awsBodyRW: ReadWriter[ApiGatewayInput] = macroRW
+  implicit val apiGatewayOutputRW: ReadWriter[ApiGatewayOutput] = macroRW
+  implicit val nextInvoiceDateInput: ReadWriter[NextInvoiceDateInput] = macroRW
+  implicit val nextInvoiceDateOutput: ReadWriter[NextInvoiceDateOutput] = macroRW
+}

--- a/src/main/scala/com/gu/invoicing/nextinvoicedate/Program.scala
+++ b/src/main/scala/com/gu/invoicing/nextinvoicedate/Program.scala
@@ -1,0 +1,26 @@
+package com.gu.invoicing.nextinvoicedate
+
+import com.gu.invoicing.nextinvoicedate.Model._
+import com.gu.invoicing.nextinvoicedate.Impl._
+import com.gu.invoicing.common.Retry._
+import scala.util.chaining._
+
+/**
+ * End of Last Invoice Period - the day after the last invoiced service period.
+ * If service period is 2020-09-27 to 2020-10-26, then end of last invoice period, or
+ * equivalently next invoice date, is 2020-10-27. Note that serviceEndDate is inclusive
+ * unlike misnomer chargedThroughDate which is exclusive. The reason why we cannot
+ * always rely on chargedThroughDate is because we do not perform bill run in real-time
+ * at point of acquisition.
+ */
+
+object Program { /** Main business logic */
+  def program(input: NextInvoiceDateInput): NextInvoiceDateOutput = retryUnsafe {
+    val NextInvoiceDateInput(subscriptionName) = input
+    val accountId           = getAccountId(subscriptionName)
+    val allInvoiceItems     = getBillingPreview(accountId)
+    val invoiceItems        = collectRelevantInvoiceItems(subscriptionName, allInvoiceItems)
+    val nextInvoiceDate     = findNextInvoiceDate(invoiceItems)
+    NextInvoiceDateOutput(nextInvoiceDate)
+  }
+}

--- a/src/main/scala/com/gu/invoicing/nextinvoicedate/README.md
+++ b/src/main/scala/com/gu/invoicing/nextinvoicedate/README.md
@@ -1,0 +1,62 @@
+## Get next invoice date (day after last invoice period)
+
+Uses [operations/billing-preview](https://www.zuora.com/developer/api-reference/#operation/POST_BillingPreview) 
+to determine *next invoice date*. The following are all equivalent interpretation of the next invoice date
+ - day after last invoiced period
+ - day after last service period
+ - day after `serviceEndDate`
+ - `chargedThroughDate` of last invoiced period
+ - first day of next invoiced period
+
+**Request:**
+
+```
+GET /next-invoice-date/{subscriptionName}
+Host: https://{apiGatewayId}.execute-api.{region}.amazonaws.com/{STAGE}
+x-api-key: ********
+```
+
+**Response:**
+
+If the date exists
+
+```
+{
+  "nextInvoiceDate": "2020-10-27"
+}
+```
+
+otherwise 
+
+```
+{}
+```
+
+### How to test in CODE
+
+#### With CLI 
+
+1. Get invoicing-api+uat@guardian.co.uk Zuora OAuth client credentials
+1. Follow docs in `Cli.scala` and create `Stage` and `Config` environmental variables
+1. Simply run something like
+    ```
+    program(NextInvoiceDateInput("A-S00000000"))
+    ```
+
+#### With Lambda
+
+1. Get fresh Janus credentials
+1. `Program.scala` contains main business logic 
+1. `deployAwsLambda CODE` will upload modified lambda package
+1. In AWS Lambda console create test event that reflects `GET /next-invoice-date/{subscriptionName}`
+    ```
+    {
+      "pathParameters": {
+        "subscriptionName": "A-S00000000"
+      }
+    }
+    ```
+1. Tail logs 
+    ```
+    export AWS_DEFAULT_REGION=eu-west-1 && awslogs get --profile membership /aws/lambda/invoicing-api-nextinvoicedate-CODE --watch
+    ```

--- a/src/test/scala/com/gu/invoicing/nextinvoicedate/NextInvoiceDateSuite.scala
+++ b/src/test/scala/com/gu/invoicing/nextinvoicedate/NextInvoiceDateSuite.scala
@@ -1,0 +1,51 @@
+package com.gu.invoicing.nextinvoicedate
+
+import java.time.LocalDate
+
+import com.gu.invoicing.nextinvoicedate.Model.InvoiceItem
+import com.gu.invoicing.nextinvoicedate.Impl.findNextInvoiceDate
+
+class NextInvoiceDateSuite extends munit.FunSuite {
+  val a = InvoiceItem(
+    "12345qwerty",
+    "A-S00000000",
+    LocalDate.parse("2020-09-27"),
+    LocalDate.parse("2020-10-26"),
+    11.99
+  )
+  val b = InvoiceItem(
+    "12345qwerty",
+    "A-S00000000",
+    LocalDate.parse("2020-10-27"),
+    LocalDate.parse("2020-11-26"),
+    11.99
+  )
+  val c = InvoiceItem(
+    "12345qwerty",
+    "A-S00000000",
+    LocalDate.parse("2020-11-27"),
+    LocalDate.parse("2020-12-26"),
+    11.99
+  )
+
+  test("Next invoice date should be first day after the current invoice service period") {
+    val actual = findNextInvoiceDate(List(a,b,c), LocalDate.parse("2020-10-16"))
+    assertEquals(actual.get, expected = b.serviceStartDate)
+  }
+  test("Next invoice date should be first day after the current invoice service period (today is left bound)") {
+    val actual = findNextInvoiceDate(List(a,b,c), LocalDate.parse("2020-09-27"))
+    assertEquals(actual.get, expected = b.serviceStartDate)
+  }
+  test("Next invoice date should be first day after the current invoice service period (today is right bound)") {
+    val actual = findNextInvoiceDate(List(a,b,c), LocalDate.parse("2020-09-26"))
+    assertEquals(actual.get, expected = b.serviceStartDate)
+  }
+  test("Next invoice date should not be determined if there is no next service period") {
+    val actual = findNextInvoiceDate(List(a), LocalDate.parse("2020-10-16"))
+    assertEquals(actual, expected = None)
+  }
+  test("Next invoice date should not be determined if there are no invoice items") {
+    val actual = findNextInvoiceDate(List(a), LocalDate.parse("2020-10-16"))
+    assertEquals(actual, expected = None)
+  }
+}

--- a/src/test/scala/com/gu/invoicing/nextinvoicedate/NextInvoiceDateSuite.scala
+++ b/src/test/scala/com/gu/invoicing/nextinvoicedate/NextInvoiceDateSuite.scala
@@ -3,7 +3,7 @@ package com.gu.invoicing.nextinvoicedate
 import java.time.LocalDate
 
 import com.gu.invoicing.nextinvoicedate.Model.InvoiceItem
-import com.gu.invoicing.nextinvoicedate.Impl.findNextInvoiceDate
+import com.gu.invoicing.nextinvoicedate.Impl.{collectRelevantInvoiceItems, findNextInvoiceDate}
 
 class NextInvoiceDateSuite extends munit.FunSuite {
   val a = InvoiceItem(
@@ -11,21 +11,32 @@ class NextInvoiceDateSuite extends munit.FunSuite {
     "A-S00000000",
     LocalDate.parse("2020-09-27"),
     LocalDate.parse("2020-10-26"),
-    11.99
+    11.99,
+    "Guardian Weekly - Domestic",
   )
   val b = InvoiceItem(
     "12345qwerty",
     "A-S00000000",
     LocalDate.parse("2020-10-27"),
     LocalDate.parse("2020-11-26"),
-    11.99
+    11.9,
+    "Guardian Weekly - Domestic",
   )
   val c = InvoiceItem(
     "12345qwerty",
     "A-S00000000",
     LocalDate.parse("2020-11-27"),
     LocalDate.parse("2020-12-26"),
-    11.99
+    11.99,
+    "Guardian Weekly - Domestic",
+  )
+  val discount = InvoiceItem(
+    "12345qwerty",
+    "A-S00000000",
+    LocalDate.parse("2020-10-27"),
+    LocalDate.parse("2020-11-26"),
+    -1.60,
+    "Discounts",
   )
 
   test("Next invoice date should be first day after the current invoice service period") {
@@ -47,5 +58,15 @@ class NextInvoiceDateSuite extends munit.FunSuite {
   test("Next invoice date should not be determined if there are no invoice items") {
     val actual = findNextInvoiceDate(List(a), LocalDate.parse("2020-10-16"))
     assertEquals(actual, expected = None)
+  }
+  test("Next invoice date should be first day after the current invoice service period") {
+    val actual = findNextInvoiceDate(List(a,b,c), LocalDate.parse("2020-10-16"))
+    assertEquals(actual.get, expected = b.serviceStartDate)
+  }
+  test("Next invoice date should not depend on discounts") {
+    val expected = b.copy(serviceStartDate = discount.serviceStartDate.plusDays(1))
+    val rawItems = List(a, discount, expected)
+    val actual = findNextInvoiceDate(collectRelevantInvoiceItems("A-S00000000", rawItems), LocalDate.parse("2020-10-16"))
+    assertEquals(actual.get, expected.serviceStartDate)
   }
 }


### PR DESCRIPTION
## What does this change?

https://trello.com/c/i0a10FyJ/1542-replace-billing-date-calculation-in-support-service-lambdas-with-calls-to-billing-preview-endpoint

Provides the ability to predict the next invoice date even if bill run has not happened, that is when `chargedThroughDate` is null, by utilising `/operations/billing-preview` Zuora API.

```
GET /next-invoice-date/A-S00000000 HTTP/1.1
Host: https://{apiGatewayId}.execute-api.{region}.amazonaws.com/{stage}
Content-Type: application/json
x-api-key: ***********
```

responds with

```
{
    "nextInvoiceDate": "2020-10-27"
}
```

## How to test

* Follow the instructions in the readme, or simply hit the above endpoint with Postman.

## How can we measure success?

Hopefully removal of custom (and buggy) implementation of preview functionality from support-service-lambdas credit processor.

## Have we considered potential risks?

There is a bit of algorithmics in determining the correct date which is tested by `NextInvoiceDateSuite.scala`.
