### PR TITLE
Increase HTTP client timeouts

### DIFF
--- a/src/main/scala/com/gu/invoicing/common/Http.scala
+++ b/src/main/scala/com/gu/invoicing/common/Http.scala
@@ -1,0 +1,12 @@
+package com.gu.invoicing.common
+
+import scalaj.http.{BaseHttp, HttpOptions}
+
+object Http extends BaseHttp(
+  options = Seq(
+    HttpOptions.connTimeout(5000),
+    HttpOptions.readTimeout(5 * 60 * 1000),
+    HttpOptions.followRedirects(false)
+  )
+)
+

--- a/src/main/scala/com/gu/invoicing/invoice/Impl.scala
+++ b/src/main/scala/com/gu/invoicing/invoice/Impl.scala
@@ -3,7 +3,7 @@ package com.gu.invoicing.invoice
 
 import com.gu.invoicing.common.ZuoraAuth.{accessToken, zuoraApiHost}
 import com.gu.invoicing.invoice.Model._
-import scalaj.http.Http
+import com.gu.invoicing.common.Http
 import scala.util.chaining._
 import com.gu.spy._
 

--- a/src/main/scala/com/gu/invoicing/nextinvoicedate/Impl.scala
+++ b/src/main/scala/com/gu/invoicing/nextinvoicedate/Impl.scala
@@ -3,7 +3,7 @@ package com.gu.invoicing.nextinvoicedate
 import java.time.LocalDate
 import com.gu.invoicing.common.ZuoraAuth.{accessToken, zuoraApiHost}
 import com.gu.invoicing.nextinvoicedate.Model._
-import scalaj.http.Http
+import com.gu.invoicing.common.Http
 import scala.util.chaining._
 import pprint._
 

--- a/src/main/scala/com/gu/invoicing/pdf/Impl.scala
+++ b/src/main/scala/com/gu/invoicing/pdf/Impl.scala
@@ -2,7 +2,7 @@ package com.gu.invoicing.pdf
 
 import com.gu.invoicing.common.ZuoraAuth.{accessToken, zuoraApiHost}
 import com.gu.invoicing.pdf.Model._
-import scalaj.http.Http
+import com.gu.invoicing.common.Http
 import scala.util.chaining._
 
 object Impl {


### PR DESCRIPTION
## What does this change?

Increases limits in attempt to address frequent Zuora socket timeouts.

## How to test

HTTP client with longer timeouts has already been tested on refund endpoint, this PR simply uses it throughout all the endpoints. 

## How can we measure success?

Less alarms due to socket timeout.

## Have we considered potential risks?

No risk.
