### PR TITLE
Workaround billing-preview not calculating tax

### DIFF
--- a/src/main/scala/com/gu/invoicing/preview/Impl.scala
+++ b/src/main/scala/com/gu/invoicing/preview/Impl.scala
@@ -31,7 +31,7 @@ object Impl {
       .pipe(read[Subscription](_))
       .ratePlans
       .flatMap(_.ratePlanCharges)
-      .filterNot(_.price < 0.0)
+      .filter(_.price > 0.0)
 
   def getFutureInvoiceItems(accountId: String, startDate: LocalDate): List[InvoiceItem] = {
     Http(s"$zuoraApiHost/v1/operations/billing-preview")

--- a/src/main/scala/com/gu/invoicing/preview/Model.scala
+++ b/src/main/scala/com/gu/invoicing/preview/Model.scala
@@ -38,8 +38,14 @@ object Model extends JsonSupport {
   case class AccessToken(
     access_token: String
   )
+  case class RatePlanCharge(
+    originalChargeId: String,
+    price: Double /* Includes tax */
+  )
+  case class RatePlan(ratePlanCharges: List[RatePlanCharge])
   case class Subscription(
-    accountId: String
+    accountId: String,
+    ratePlans: List[RatePlan],
   )
   case class Publication(       /* Contrast with InvoiceItem                               */
     publicationDate: LocalDate, /* Date of paper printed on cover                          */
@@ -48,16 +54,18 @@ object Model extends JsonSupport {
     productName: String,        /* For example Newspaper Delivery                          */
     chargeName: String,         /* For example Sunday                                      */
     dayOfWeek: DayOfWeek,       /* Strongly typed day of publication                       */
-    price: Double,              /* Charge of single publication                            */
+    price: Double,              /* Charge of single publication (including tax)            */
   )
   case class InvoiceItem(
     id: String,
     subscriptionName: String,
     serviceStartDate: LocalDate,
     serviceEndDate: LocalDate,
-    chargeAmount: Double,
+    chargeAmount: Double,         /* Does NOT include tax! */
     productName: String,
     chargeName: String,
+    taxAmount: Double,            /* Not provided by billing-preview but will be available on past invoice items */
+    chargeId: String,             /* We use this to determine chargeAmount including tax from RatePlanCharge */
   )
   case class BillingPreview(
     accountId: String,
@@ -99,7 +107,9 @@ object Model extends JsonSupport {
   // ************************************************************************
   // Codecs
   // ************************************************************************
-  implicit val subscription: ReadWriter[Subscription] = macroRW
+  implicit val ratePlanRW: ReadWriter[RatePlan] = macroRW
+  implicit val ratePlanChargeRW: ReadWriter[RatePlanCharge] = macroRW
+  implicit val subscriptionRW: ReadWriter[Subscription] = macroRW
   implicit val invoiceItem: ReadWriter[InvoiceItem] = macroRW
   implicit val billingPreview: ReadWriter[BillingPreview] = macroRW
   implicit val invoice: ReadWriter[Invoice] = macroRW

--- a/src/main/scala/com/gu/invoicing/preview/Program.scala
+++ b/src/main/scala/com/gu/invoicing/preview/Program.scala
@@ -13,12 +13,14 @@ object Program { /** Main business logic */
   def program(input: PreviewInput): PreviewOutput = retryUnsafe {
     val PreviewInput(subscriptionName, start, end) = input
     val accountId             = getAccountId(subscriptionName)
+    val ratePlanCharges       = getRatePlanCharges(subscriptionName, start)
     val pastInvoiceItems      = getPastInvoiceItems(accountId, subscriptionName, start)
     val futureInvoiceItems    = getFutureInvoiceItems(accountId, start)
     val allInvoiceItems       = pastInvoiceItems ++ futureInvoiceItems
     val invoiceItems          = collectRelevantInvoiceItems(subscriptionName, allInvoiceItems)
-    val nextInvoiceDate       = findNextInvoiceDate(invoiceItems)
-    val publications          = invoiceItems.flatMap(splitInvoiceItemIntoPublications)
+    val itemsWithTax          = invoiceItems.map(addTax(_, ratePlanCharges))
+    val nextInvoiceDate       = findNextInvoiceDate(itemsWithTax)
+    val publications          = itemsWithTax.flatMap(splitInvoiceItemIntoPublications)
     val affectedPublications  = findAffectedPublicationsWithRange(publications, start, end)
     PreviewOutput(subscriptionName, nextInvoiceDate, start, end, affectedPublications)
   }

--- a/src/test/scala/com/gu/invoicing/preview/PricePerPublicationSuite.scala
+++ b/src/test/scala/com/gu/invoicing/preview/PricePerPublicationSuite.scala
@@ -14,6 +14,8 @@ class PricePerPublicationSuite extends munit.FunSuite {
       6.000000000,
       "Guardian Weekly - Domestic",
       "GW Oct 18 - First 6 issues - Domestic",
+      0.0,
+      "aChargeId",
     )
     assertEquals(pricePerPublication(item), expected = 1.0)
   }
@@ -26,6 +28,8 @@ class PricePerPublicationSuite extends munit.FunSuite {
       37.500000000,
       "Guardian Weekly - Domestic",
       "GW Oct 18 - Quarterly - Domestic",
+      0.0,
+      "aChargeId",
     )
     assertEquals(pricePerPublication(item), expected = 2.89)
   }
@@ -38,6 +42,8 @@ class PricePerPublicationSuite extends munit.FunSuite {
       8.16,
       "Newspaper Delivery",
       "Friday",
+      0.0,
+      "aChargeId",
     )
     assertEquals(pricePerPublication(item), expected = 2.04)
   }


### PR DESCRIPTION
## What does this change?

* Unfortunately billing-preview does [not](https://www.zuora.com/developer/api-reference/#operation/POST_BillingPreview) calculate tax

  > This field returns 0 becasue the BillingPreview operation does not calculate taxes for charges in the subscription.
* Zuora support provided [no solution ](https://support.zuora.com/hc/en-us/requests/281646).
* As a workaround we obtain `chargeAmount` inclusive of tax via `RatePlanCharge`.


## How to test

Issue can be replicate for, say, Guardian Weekly billed to Quebec, Canada . For example, price of single 6-for-6 Publication would be calculated as 0.87 CAD instead of 1 CAD.

## How can we measure success?

Satisfy test in prod currently running as part of https://github.com/guardian/support-service-lambdas/pull/751

## Have we considered potential risks?

No major risk.
