### PR TITLE
Separate tax calculation for past and future InvoiceItems

### DIFF
--- a/src/main/scala/com/gu/invoicing/preview/Program.scala
+++ b/src/main/scala/com/gu/invoicing/preview/Program.scala
@@ -14,13 +14,14 @@ object Program { /** Main business logic */
     val PreviewInput(subscriptionName, start, end) = input
     val accountId             = getAccountId(subscriptionName)
     val ratePlanCharges       = getRatePlanCharges(subscriptionName, start)
-    val pastInvoiceItems      = getPastInvoiceItems(accountId, subscriptionName, start)
-    val futureInvoiceItems    = getFutureInvoiceItems(accountId, start)
-    val allInvoiceItems       = pastInvoiceItems ++ futureInvoiceItems
-    val invoiceItems          = collectRelevantInvoiceItems(subscriptionName, allInvoiceItems)
-    val itemsWithTax          = invoiceItems.map(addTax(_, ratePlanCharges))
-    val nextInvoiceDate       = findNextInvoiceDate(itemsWithTax)
-    val publications          = itemsWithTax.flatMap(splitInvoiceItemIntoPublications)
+    val pastInvoiceItems      = getPastInvoiceItems(accountId, subscriptionName, start).map(addTaxToPastInvoiceItems)
+    val futureInvoiceItems    = getFutureInvoiceItems(accountId, start).map(addTaxToFutureInvoiceItems(_, ratePlanCharges))
+    val pastItemsWithTax      = pastInvoiceItems.map(addTaxToPastInvoiceItems)
+    val futureItemsWithTax    = futureInvoiceItems.map(addTaxToFutureInvoiceItems(_, ratePlanCharges))
+    val allItemsWithTax       = pastItemsWithTax ++ futureItemsWithTax
+    val invoiceItems          = collectRelevantInvoiceItems(subscriptionName, allItemsWithTax)
+    val nextInvoiceDate       = findNextInvoiceDate(invoiceItems)
+    val publications          = invoiceItems.flatMap(splitInvoiceItemIntoPublications)
     val affectedPublications  = findAffectedPublicationsWithRange(publications, start, end)
     PreviewOutput(subscriptionName, nextInvoiceDate, start, end, affectedPublications)
   }


### PR DESCRIPTION
## What does this change?

`originalChargeId` returned from `subscriptions/A-S00000000` turns out to be mutable so it is not a reliable way of joining past invoice items with `RatePlanCharge`s. Turns out `taxAmount` is correctly populated for past `InvoiceItem`s so we simply use that to determine the tax. The way we determine tax for future `InvoiceItem`s remains unchanged from https://github.com/guardian/invoicing-api/pull/25 workaround.

## How to test

Currently I am depending on [`testInProdPreviewPublications`](https://github.com/guardian/support-service-lambdas/pull/751) to obtain failing Subscriptions. However I am not quite sure what causes `originalChargeId` to change...

## Have we considered potential risks?

No risk until switchover.