### PR TITLE
Build native linux image from any platform via Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN yum -y install zip unzip
 RUN set -x \
   && SBT_VER="1.4.4" \
   && curl -Ls https://github.com/sbt/sbt/releases/download/v${SBT_VER}/sbt-$SBT_VER.tgz > /opt/sbt-${SBT_VER}.tgz \
+  && echo "2efae0876119af7bfce8b3621b43b08c51381352916ac9de6156b1251ec26d45 /opt/sbt-${SBT_VER}.tgz" | sha256sum --check \
   && tar -zxf /opt/sbt-${SBT_VER}.tgz -C /opt
 
 ENV PATH="/opt/sbt/bin:$PATH"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+# Make sure gcc et al are present for native linking
+FROM oracle/graalvm-ce:20.2.0-java11
+
+# Intended for: zip -r -j target/scala-2.13/invoicing-api.zip target/scala-2.13/bootstrap
+RUN yum -y install zip
+
+# Install sbt and coursier via www.scala-lang.org/2020/06/29/one-click-install.html
+RUN curl -Lo /opt/cs https://git.io/coursier-cli-linux && chmod +x opt/cs
+RUN echo 'Y' | ./opt/cs setup
+ENV PATH="/root/.local/share/coursier/bin:$PATH"
+
+# Manage JVM with coursier
+RUN cs java-home --jvm graalvm-java11:20.2.0
+
+# Populate sbt cache to speed up build
+RUN set -x \
+  && cd /tmp \
+  && echo "ThisBuild / scalaVersion := \"2.13.3\"" >> build.sbt \
+  && mkdir -p project \
+  && echo "sbt.version=1.4.4" >> project/build.properties \
+  && echo "object Test" >> Test.scala \
+  && sbt compile \
+  && sbt compile \
+  && rm Test.scala \
+  && rm -rf project \
+  && rm -rf target \
+  && rm build.sbt
+
+# Intended for: docker run -v "$(pwd -P)":/invoicing-api invoicing-api
+WORKDIR /invoicing-api
+CMD ["sbt", "packageNativeAwsImage"]
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,15 +2,15 @@
 FROM oracle/graalvm-ce:20.2.0-java11
 
 # Intended for: zip -r -j target/scala-2.13/invoicing-api.zip target/scala-2.13/bootstrap
-RUN yum -y install zip
+RUN yum -y install zip unzip
 
-# Install sbt and coursier via www.scala-lang.org/2020/06/29/one-click-install.html
-RUN curl -Lo /opt/cs https://git.io/coursier-cli-linux && chmod +x opt/cs
-RUN ./opt/cs setup --yes
-ENV PATH="/root/.local/share/coursier/bin:$PATH"
+# Install sbt
+RUN set -x \
+  && SBT_VER="1.4.4" \
+  && curl -Ls https://github.com/sbt/sbt/releases/download/v${SBT_VER}/sbt-$SBT_VER.tgz > /opt/sbt-${SBT_VER}.tgz \
+  && tar -zxf /opt/sbt-${SBT_VER}.tgz -C /opt
 
-# Manage JVM with coursier
-RUN cs java-home --jvm graalvm-java11:20.2.0
+ENV PATH="/opt/sbt/bin:$PATH"
 
 # Intended for: docker run -v "$(pwd -P)":/invoicing-api invoicing-api
 WORKDIR /invoicing-api

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,25 +6,11 @@ RUN yum -y install zip
 
 # Install sbt and coursier via www.scala-lang.org/2020/06/29/one-click-install.html
 RUN curl -Lo /opt/cs https://git.io/coursier-cli-linux && chmod +x opt/cs
-RUN echo 'Y' | ./opt/cs setup
+RUN ./opt/cs setup --yes
 ENV PATH="/root/.local/share/coursier/bin:$PATH"
 
 # Manage JVM with coursier
 RUN cs java-home --jvm graalvm-java11:20.2.0
-
-# Populate sbt cache to speed up build
-RUN set -x \
-  && cd /tmp \
-  && echo "ThisBuild / scalaVersion := \"2.13.3\"" >> build.sbt \
-  && mkdir -p project \
-  && echo "sbt.version=1.4.4" >> project/build.properties \
-  && echo "object Test" >> Test.scala \
-  && sbt compile \
-  && sbt compile \
-  && rm Test.scala \
-  && rm -rf project \
-  && rm -rf target \
-  && rm build.sbt
 
 # Intended for: docker run -v "$(pwd -P)":/invoicing-api invoicing-api
 WORKDIR /invoicing-api


### PR DESCRIPTION
## What does this change?

TeamCity can build correct linux native-image as `sbt-native-image` executes within linux container. However when building on MacOS then `sbt-native-image` will build executable native to MacOS which will not work in Amazon Linux lambda. This PR provides a docker image which can be used to build linux invoice-api native lambdas on any platform. 

## How to test

1. Get fresh janus credentials
1. Install docker
1. Give docker more memory (I have gave it 6.25)
1. execute `deployAwsLambda` which will build the native image and upload lambdas

Corresponding manual steps would be

1. `docker build -t invoicing-api .` (only necessary first time and if there are any changes to `Dockerfile`)
1.  `docker run -it -v "$(pwd -P)":/invoicing-api invoicing-api bash` 
1. `sbt packageNativeAwsImage`
1. `targetDir=target/scala-2.13 && zip -r -j ${targetDir}/invoicing-api.zip ${targetDir}/bootstrap`
1. Upload lambda deployment package `target/scala-2.13/invoicing-api.zip`

## How can we measure success?

If bypassing TeamCity and RiffRaff during development would speed up feedback loop.

## Have we considered potential risks?

No risk.