### PR TITLE
Fix checking if InvoiceItem falls within relevant range

### DIFF
--- a/src/main/scala/com/gu/invoicing/preview/Program.scala
+++ b/src/main/scala/com/gu/invoicing/preview/Program.scala
@@ -20,8 +20,8 @@ object Program { /** Main business logic */
     val accountId             = getAccountId(subscriptionName)
     val allRatePlanCharges    = getRatePlanCharges(subscriptionName, start)
     val paidRatePlanCharges   = allRatePlanCharges.filter(_.price > 0.0)
-    val pastInvoiceItems      = getPastInvoiceItems(accountId, subscriptionName, start).map(addTaxToPastInvoiceItems)
-    val futureInvoiceItems    = getFutureInvoiceItems(accountId, start).map(addTaxToFutureInvoiceItems(_, paidRatePlanCharges))
+    val pastInvoiceItems      = getPastInvoiceItems(accountId, subscriptionName, start, end)
+    val futureInvoiceItems    = getFutureInvoiceItems(accountId, start)
     val pastItemsWithTax      = pastInvoiceItems.map(addTaxToPastInvoiceItems)
     val futureItemsWithTax    = futureInvoiceItems.map(addTaxToFutureInvoiceItems(_, paidRatePlanCharges))
     val allItemsWithTax       = pastItemsWithTax ++ futureItemsWithTax


### PR DESCRIPTION
## What does this change?

* We should select the InvoiceItem if either its `serviceStartDate` or `serviceEndDate` falls within the input range (provided from query parameters).
* Secondary bug fix: remove duplicated tax calculation


## How to test

Tested via CLI against subscriptions flagged by  [`testInProdPreviewPublications`](https://trello.com/c/o6Q3AQd3/1760-monitor-test-in-production-tip-for-new-billing-preview-functionality)

## How can we measure success?

Less discrepancies in `testInProdPreviewPublications`


## Have we considered potential risks?

No risk.
