### PR TITLE
Fix filtering of past invoice items

### DIFF
--- a/src/main/scala/com/gu/invoicing/preview/Cli.scala
+++ b/src/main/scala/com/gu/invoicing/preview/Cli.scala
@@ -16,6 +16,11 @@ import pprint._
  *   export Config = { "clientId": "******", "clientSecret": "*****"}
  */
 object Cli {
-  def main(args: Array[String]): Unit =
-    program(PreviewInput("A-S00000000", LocalDate.parse("2020-11-13"), LocalDate.parse("2020-12-25"))) tap(log(_))
+  def main(args: Array[String]): Unit = {
+    val input = """A-S0000000?startDate=2021-02-14&endDate=2021-02-15"""
+    input match {
+      case s"$sub?startDate=$startDate&endDate=$endDate" =>
+        program(PreviewInput(sub, LocalDate.parse(startDate), LocalDate.parse(endDate))) tap(log(_))
+    }
+  }
 }

--- a/src/main/scala/com/gu/invoicing/preview/Impl.scala
+++ b/src/main/scala/com/gu/invoicing/preview/Impl.scala
@@ -102,7 +102,8 @@ object Impl {
       .filter  { _.status == "Posted"                   }
       .flatMap { _.invoiceItems                         }
       .filter  { _.subscriptionName == subscriptionName }
-      .filter  { item => List(item.serviceStartDate, item.serviceEndDate).exists(_.inClosedInterval(startDate, endDate)) }
+      .filterNot { _.serviceEndDate.isBefore(startDate) }
+      .filterNot { _.serviceStartDate.isAfter(endDate)  }
       .toList
       .sortBy(_.serviceStartDate)
 


### PR DESCRIPTION
## What does this change?

* Exclude past invoice items with serviceEndDate before requested start date of range 
* Exclude past invoice items with serviceStartDate after requested end date of range

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
