### PR TITLE
Find nextInvoiceDate using currently active InvoiceItem

### DIFF
--- a/src/main/scala/com/gu/invoicing/preview/Impl.scala
+++ b/src/main/scala/com/gu/invoicing/preview/Impl.scala
@@ -133,12 +133,12 @@ object Impl {
   def findNextInvoiceDate(
     items: List[InvoiceItem],
     today: LocalDate = LocalDate.now()
-  ): Option[LocalDate] =
+  ): Option[LocalDate] = {
     items
-      .filter(_.serviceStartDate.isAfter(today))
       .sortBy(_.serviceStartDate)
-      .headOption
-      .map(_.serviceStartDate)
+      .find(item => today.inClosedInterval(item.serviceStartDate, item.serviceEndDate))
+      .map(_.serviceEndDate.plusDays(1))
+  }
 
   def findAffectedPublicationsWithRange(
     publications: List[Publication],


### PR DESCRIPTION
* Previously it would fail if currently active InvoiceItem was the last InvoiceItem in the range, because in this case `_.serviceStartDate.isAfter(today)` would be false
* This PR changes determination of nextInvoiceDate by first identifying precisely the current active InvoiceItem and taking the day after `serviceEndDate`.

