### PR TITLE
Invoice items should not include multiple subscriptions

### DIFF
--- a/src/main/scala/com/gu/invoicing/preview/Impl.scala
+++ b/src/main/scala/com/gu/invoicing/preview/Impl.scala
@@ -64,7 +64,11 @@ object Impl {
       .pipe(discountedPublicationPrice => publication.copy(price = discountedPublicationPrice))
   }
 
-  def getFutureInvoiceItems(accountId: String, startDate: LocalDate): List[InvoiceItem] = {
+  def getFutureInvoiceItems(
+    accountId: String,
+    subscriptionName: String,
+    startDate: LocalDate
+  ): List[InvoiceItem] = {
     Http(s"$zuoraApiHost/v1/operations/billing-preview")
       .header("Authorization", s"Bearer $accessToken")
       .header("Content-Type", "application/json")
@@ -83,6 +87,7 @@ object Impl {
       .pipe(read[BillingPreview](_))
       .invoiceItems
       .filter(_.chargeAmount > 0.0)
+      .filter(_.subscriptionName == subscriptionName)
   }
 
   def getPastInvoiceItems(

--- a/src/main/scala/com/gu/invoicing/preview/Program.scala
+++ b/src/main/scala/com/gu/invoicing/preview/Program.scala
@@ -21,7 +21,7 @@ object Program { /** Main business logic */
     val allRatePlanCharges    = getRatePlanCharges(subscriptionName, start)
     val paidRatePlanCharges   = allRatePlanCharges.filter(_.price > 0.0)
     val pastInvoiceItems      = getPastInvoiceItems(accountId, subscriptionName, start, end)
-    val futureInvoiceItems    = getFutureInvoiceItems(accountId, start)
+    val futureInvoiceItems    = getFutureInvoiceItems(accountId, subscriptionName, start)
     val pastItemsWithTax      = pastInvoiceItems.map(addTaxToPastInvoiceItems)
     val futureItemsWithTax    = futureInvoiceItems.map(addTaxToFutureInvoiceItems(_, paidRatePlanCharges))
     val allItemsWithTax       = pastItemsWithTax ++ futureItemsWithTax


### PR DESCRIPTION
getFutureInvoiceItems would previously return invoice items of all subscriptions (even if account has multiple different subscriptions) but we need to narrow it down to a particular subscription requested by the user.

