### PR TITLE
6 for 6 is sometimes 7 weeks due to extension during Christmas holidays

### DIFF
--- a/src/main/scala/com/gu/invoicing/preview/Impl.scala
+++ b/src/main/scala/com/gu/invoicing/preview/Impl.scala
@@ -236,6 +236,7 @@ object Impl {
       case 25 | 26 => 26 // Semi_annual
       case  3 |  4 => 4  // Month
       case  5 |  6 => 6  // 6 for 6
+      case       7 => 6  // 6 for 6 (7 weeks billing period might happen during Christmas time when have to extend to account for missing issue)
       case  v => log(invoiceItem, s"WARN: Check publication price for unusual billing period of $weeks"); v
     }
 


### PR DESCRIPTION
## What does this change?

* https://github.com/guardian/zuora-6for6-modifier
* During Christmas holidays some subscribers may miss one issue but we have to honour 6 issues for 6 weeks so billing period might be extended from 6 weeks to 7 weeks. Without accounting for this 7 weeks billing period, subscribers might be credited 0.86 instead of 1.

## How to test

`testInProdPreviewPublications` identified a problematic subscriptions which was then tested locally via CLI.scala.

