### PR TITLE
Do not exclude negative invoices

### DIFF
--- a/src/main/scala/com/gu/invoicing/preview/Impl.scala
+++ b/src/main/scala/com/gu/invoicing/preview/Impl.scala
@@ -103,7 +103,6 @@ object Impl {
       .pipe(read[Invoices](_))
       .invoices
       .iterator
-      .filter  { _.amount >= 0.0                        }
       .filter  { _.status == "Posted"                   }
       .flatMap { _.invoiceItems                         }
       .filter  { _.subscriptionName == subscriptionName }


### PR DESCRIPTION
* Negative invoices can be created, for example, when holiday spans multiple billing periods corresponding to multiple invoices, but all the credits are applied to a single invoice, which might cause too much credit to be applied to a single invoice. For example, sum of positive invoice items might be 5, but the sum of negative invoice items might be -10, in which case total invoice amount will be -5. Such an invoice is still a valid invoice which contains relevant dates for calculation of individual publications so should not be excluded.
* Related info regarding negative invoices
   *   https://github.com/guardian/zuora-creditor
   *   `ALARM: zuora-creditor PROD: number of Invoices credited > 0`

