### PR TITLE
Try sooner targetDate because billing-preview cant take >30 seconds

### DIFF
--- a/src/main/scala/com/gu/invoicing/preview/Impl.scala
+++ b/src/main/scala/com/gu/invoicing/preview/Impl.scala
@@ -67,7 +67,7 @@ object Impl {
   def getFutureInvoiceItems(
     accountId: String,
     subscriptionName: String,
-    startDate: LocalDate
+    targetDate: LocalDate
   ): List[InvoiceItem] = {
     Http(s"$zuoraApiHost/v1/operations/billing-preview")
       .header("Authorization", s"Bearer $accessToken")
@@ -76,7 +76,7 @@ object Impl {
         s"""
            |{
            |    "accountId": "$accountId",
-           |    "targetDate": "${startDate.plusYears(3)}",
+           |    "targetDate": "${targetDate.plusDays(1)}",
            |    "assumeRenewal": "Autorenew"
            |}
            |""".stripMargin

--- a/src/main/scala/com/gu/invoicing/preview/Program.scala
+++ b/src/main/scala/com/gu/invoicing/preview/Program.scala
@@ -21,7 +21,7 @@ object Program { /** Main business logic */
     val allRatePlanCharges    = getRatePlanCharges(subscriptionName, start)
     val paidRatePlanCharges   = allRatePlanCharges.filter(_.price > 0.0)
     val pastInvoiceItems      = getPastInvoiceItems(accountId, subscriptionName, start, end)
-    val futureInvoiceItems    = getFutureInvoiceItems(accountId, subscriptionName, start)
+    val futureInvoiceItems    = getFutureInvoiceItems(accountId, subscriptionName, end)
     val pastItemsWithTax      = pastInvoiceItems.map(addTaxToPastInvoiceItems)
     val futureItemsWithTax    = futureInvoiceItems.map(addTaxToFutureInvoiceItems(_, paidRatePlanCharges))
     val allItemsWithTax       = pastItemsWithTax ++ futureItemsWithTax


### PR DESCRIPTION
## What does this change?

billing-preview call is not performant when target date is far in the future. It can take more than 30 seconds so the holiday-stop-api times out

```
testInProdPreviewPublications failed A00000000?startDate=2021-03-08&endDate=2021-03-08 because invoicing-api error: ZuoraApiFailure({"message": "Endpoint request timed out"})
```

It might be sufficient to simply use the user provided end date of the range now.

## How to test

`testInProdPreviewPublications`
