### PR TITLE
Handle pagination of past InvoiceItems

### DIFF
--- a/src/main/scala/com/gu/invoicing/preview/Model.scala
+++ b/src/main/scala/com/gu/invoicing/preview/Model.scala
@@ -88,7 +88,8 @@ object Model extends JsonSupport {
   )
   case class Invoices(
     invoices: List[Invoice],
-    success: Boolean
+    success: Boolean,
+    nextPage: Option[String] = None,
   )
 
   // ************************************************************************


### PR DESCRIPTION
## What does this change?

[GET_TransactionInvoice](https://www.zuora.com/developer/api-reference/#operation/GET_TransactionInvoice) used to fetch past InvoiceItems returns paginated results when there are too many records

```
pageSize   integer <= 40
           Default: 20
           Number of rows returned per page.
```

## How to test

Tested on subscriptions flagged by `testInProdPreviewPublications`

