### PR TITLE
Account that owns invoices might differ from account that owns the subscription

### DIFF
--- a/src/main/scala/com/gu/invoicing/preview/Impl.scala
+++ b/src/main/scala/com/gu/invoicing/preview/Impl.scala
@@ -13,13 +13,13 @@ import scala.annotation.tailrec
 import scala.math.BigDecimal.RoundingMode
 
 object Impl {
-  def getAccountId(name: String): String = {
+  def getInvoiceOwnerAccountId(name: String): String = {
     Http(s"$zuoraApiHost/v1/subscriptions/$name")
       .header("Authorization", s"Bearer $accessToken")
       .asString
       .body
       .pipe(read[Subscription](_))
-      .accountId
+      .invoiceOwnerAccountId
   }
 
   /* Needed to obtain chargeAmount with tax included as billing-preview is not inclusive of tax */
@@ -65,7 +65,7 @@ object Impl {
   }
 
   def getFutureInvoiceItems(
-    accountId: String,
+    invoiceOwnerAccountId: String,
     subscriptionName: String,
     targetDate: LocalDate
   ): List[InvoiceItem] = {
@@ -75,7 +75,7 @@ object Impl {
       .postData(
         s"""
            |{
-           |    "accountId": "$accountId",
+           |    "accountId": "$invoiceOwnerAccountId",
            |    "targetDate": "${targetDate.plusDays(1)}",
            |    "assumeRenewal": "Autorenew"
            |}
@@ -91,7 +91,7 @@ object Impl {
   }
 
   def getPastInvoiceItems(
-    account: String,
+    invoiceOwnerAccountId: String,
     subscriptionName: String,
     startDate: LocalDate,
     endDate: LocalDate,
@@ -112,7 +112,7 @@ object Impl {
       }
     }
 
-    go(s"v1/transactions/invoices/accounts/$account?pageSize=40", Nil)
+    go(s"v1/transactions/invoices/accounts/$invoiceOwnerAccountId?pageSize=40", Nil)
       .iterator
       .filter  { _.status == "Posted"                   }
       .flatMap { _.invoiceItems                         }

--- a/src/main/scala/com/gu/invoicing/preview/Model.scala
+++ b/src/main/scala/com/gu/invoicing/preview/Model.scala
@@ -48,7 +48,7 @@ object Model extends JsonSupport {
   )
   case class RatePlan(ratePlanCharges: List[RatePlanCharge])
   case class Subscription(
-    accountId: String,
+    invoiceOwnerAccountId: String,
     ratePlans: List[RatePlan],
   )
   case class Publication(       /* Contrast with InvoiceItem                               */

--- a/src/main/scala/com/gu/invoicing/preview/Program.scala
+++ b/src/main/scala/com/gu/invoicing/preview/Program.scala
@@ -17,11 +17,11 @@ import pprint._
 object Program { /** Main business logic */
   def program(input: PreviewInput): PreviewOutput = retryUnsafe {
     val PreviewInput(subscriptionName, start, end) = input
-    val accountId             = getAccountId(subscriptionName)
+    val invoiceOwnerAccountId = getInvoiceOwnerAccountId(subscriptionName)
     val allRatePlanCharges    = getRatePlanCharges(subscriptionName, start)
     val paidRatePlanCharges   = allRatePlanCharges.filter(_.price > 0.0)
-    val pastInvoiceItems      = getPastInvoiceItems(accountId, subscriptionName, start, end)
-    val futureInvoiceItems    = getFutureInvoiceItems(accountId, subscriptionName, end)
+    val pastInvoiceItems      = getPastInvoiceItems(invoiceOwnerAccountId, subscriptionName, start, end)
+    val futureInvoiceItems    = getFutureInvoiceItems(invoiceOwnerAccountId, subscriptionName, end)
     val pastItemsWithTax      = pastInvoiceItems.map(addTaxToPastInvoiceItems)
     val futureItemsWithTax    = futureInvoiceItems.map(addTaxToFutureInvoiceItems(_, paidRatePlanCharges))
     val allItemsWithTax       = pastItemsWithTax ++ futureItemsWithTax


### PR DESCRIPTION
## What does this change?

There are are some (low frequency) cases where account associated with subscription (`accountId`) is different from account associated with invoices (`invoiceOwnerAccountId`), so fetching InvoiceItems from account that does not own the invoices would return empty list.

Most of these are not auto-renewing so credit request should be [blocked](https://github.com/guardian/support-service-lambdas/blob/5b53dc194f1c950a8d5864e8c977f939415a9ed7/handlers/holiday-stop-processor/src/test/scala/com/gu/holidaystopprocessor/HolidayStopProcessTest.scala#L131) at the point of creation anyways.

## How to test

Relevant subs could be identifies like so

```
SELECT * 
FROM clean.zuora_subscription
WHERE account_id <> invoice_owner_id
AND status = 'Active'
AND auto_renew = true
```

## Have we considered potential risks?

In majority of cases `accountId = invoiceOwnerAccountId` so this change should be low risk.
