### PR TITLE
Add endpoint to refund erroneous payments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
-.*
-!/.gitignore
+.idea
+.bloop
+.bsp
 dist/*
 target/
 lib_managed/

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,5 @@
+version = 3.4.0
+
+runner.dialect = scala213
+
+maxColumn = 100

--- a/build.sbt
+++ b/build.sbt
@@ -51,6 +51,7 @@ deployAwsLambda := {
     .#&&(updateLambda("invoicing-api-pdf"))
     .#&&(updateLambda("invoicing-api-nextinvoicedate"))
     .#&&(updateLambda("invoicing-api-preview"))
+    .#&&(updateLambda("invoicing-api-refund-erroneous-payment"))
     .!
 }
 

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -362,7 +362,7 @@ Resources:
     Properties:
       RestApiId: !Ref InvoicingApi
       ParentId: !GetAtt InvoicingApi.RootResourceId
-      PathPart: refundErroneousPayment
+      PathPart: refund-erroneous-payment
     DependsOn: InvoicingApi
 
   RefundErroneousPaymentMethod:
@@ -621,3 +621,13 @@ Resources:
               - Effect: Allow
                 Action: s3:GetObject
                 Resource: arn:aws:s3::*:membership-dist/*
+
+  RefundErroneousPaymentLambdaPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:invokeFunction
+      FunctionName: !Sub invoicing-api-refund-erroneous-payment-${Stage}
+      Principal: apigateway.amazonaws.com
+    DependsOn:
+      - RefundErroneousPaymentLambda
+      - RefundErroneousPaymentMethod

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -608,6 +608,7 @@ Resources:
                 - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/invoicing-api-pdf-${Stage}:log-stream:*
                 - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/invoicing-api-nextinvoicedate-${Stage}:log-stream:*
                 - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/invoicing-api-preview-${Stage}:log-stream:*
+                - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/invoicing-api-refund-erroneous-payment-${Stage}:log-stream:*
 
         - PolicyName: ReadPrivateCredentials
           PolicyDocument:

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -244,6 +244,26 @@ Resources:
     DependsOn:
       - InvoicingLambdaRole
 
+  RefundErroneousPaymentLambda:
+    Type: AWS::Lambda::Function
+    Properties:
+      Description: Apply refund to Zuora invoice by shuffling credit balances.
+      FunctionName: !Sub invoicing-api-refund-erroneous-payment-${Stage}
+      Code:
+        S3Bucket: membership-dist
+        S3Key: !Sub support/${Stage}/invoicing-api/invoicing-api.zip
+      Handler: com.gu.invoicing.refundErroneousPayment.Lambda::handleRequest
+      Environment:
+        Variables:
+          Stage: !Ref Stage
+          Config: !Sub '{{resolve:ssm:/invoicing-api/${Stage}/config:1}}'
+      Role: !GetAtt InvoicingLambdaRole.Arn
+      MemorySize: 3008
+      Runtime: provided
+      Timeout: 900
+    DependsOn:
+      - InvoicingLambdaRole
+
   # ****************************************************************************
   # API
   # ****************************************************************************
@@ -333,6 +353,34 @@ Resources:
       - InvoicingApi
       - RefundEndpoint
       - RefundLambda
+
+  # ****************************************************************************
+  # POST /refund-erroneous-payment
+  # ****************************************************************************
+  RefundErroneousPaymentEndpoint:
+    Type: AWS::ApiGateway::Resource
+    Properties:
+      RestApiId: !Ref InvoicingApi
+      ParentId: !GetAtt InvoicingApi.RootResourceId
+      PathPart: refundErroneousPayment
+    DependsOn: InvoicingApi
+
+  RefundErroneousPaymentMethod:
+    Type: AWS::ApiGateway::Method
+    Properties:
+      ApiKeyRequired: true
+      AuthorizationType: NONE
+      RestApiId: !Ref InvoicingApi
+      ResourceId: !Ref RefundErroneousPaymentEndpoint
+      HttpMethod: POST
+      Integration:
+        Type: AWS_PROXY
+        IntegrationHttpMethod: POST # this for the interaction between API Gateway and Lambda and MUST be POST
+        Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${RefundErroneousPaymentLambda.Arn}/invocations
+    DependsOn:
+      - InvoicingApi
+      - RefundErroneousPaymentEndpoint
+      - RefundErroneousPaymentLambda
 
   # ****************************************************************************
   # GET /invoices

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -20,4 +20,5 @@ deployments:
         - invoicing-api-pdf-
         - invoicing-api-nextinvoicedate-
         - invoicing-api-preview-
+        - invoicing-api-refund-erroneous-payment-
     dependencies: [cfn]

--- a/src/main/scala/bootstrap.scala
+++ b/src/main/scala/bootstrap.scala
@@ -42,6 +42,9 @@ object bootstrap {
       case "com.gu.invoicing.refund.Lambda::handleRequest" =>
         com.gu.invoicing.refund.Lambda.handleRequest(input)
 
+      case "com.gu.invoicing.refundErroneousPayment.Lambda::handleRequest" =>
+        com.gu.invoicing.refundErroneousPayment.Lambda.handleRequest(input)
+
       case unknownHandler =>
         throw new RuntimeException(s"Unknown function handler in custom runtime: $unknownHandler")
     }

--- a/src/main/scala/com/gu/invoicing/refundErroneousPayment/Impl.scala
+++ b/src/main/scala/com/gu/invoicing/refundErroneousPayment/Impl.scala
@@ -1,0 +1,109 @@
+package com.gu.invoicing.refundErroneousPayment
+
+import com.gu.invoicing.common.Http
+import com.gu.invoicing.common.ZuoraAuth.{accessToken, zuoraApiHost}
+import com.gu.invoicing.refundErroneousPayment.Model._
+
+import scala.util.chaining._
+
+/**
+  * Zuora API client and implementation details
+  */
+object Impl {
+
+  def getAccountBalance(accountId: String): BigDecimal = {
+    Http(s"$zuoraApiHost/v1/accounts/$accountId")
+      .header("Authorization", s"Bearer $accessToken")
+      .asString
+      .body
+      .pipe(read[Account](_))
+      .metrics
+      .balance
+  }
+
+  def createRefundObject(amount: BigDecimal,
+                         paymentId: String,
+                         comment: String): String = {
+    Http(s"$zuoraApiHost/v1/object/refund")
+      .header("Authorization", s"Bearer $accessToken")
+      .header("Content-Type", "application/json")
+      .postData(
+        s"""
+           |{
+           |  "Amount": $amount,
+           |  "Comment": "$comment",
+           |  "PaymentId": "$paymentId",
+           |  "Type": "Electronic"
+           |}
+           |""".stripMargin)
+      .method("POST")
+      .asString
+      .body
+      .pipe(body => read[RefundResult](body))
+      .Id
+  }
+
+  def getRefundStatus(refundId: String): String = {
+    Http(s"$zuoraApiHost/v1/object/refund/$refundId")
+      .header("Authorization", s"Bearer $accessToken")
+      .asString
+      .body
+      .pipe(read[Refund](_))
+      .Status
+  }
+
+  def getBalancingInvoice(accountId: String, invoiceAmount:BigDecimal):String = {
+    val body = Http(s"$zuoraApiHost/v1/action/query")
+      .header("Authorization", s"Bearer $accessToken")
+      .header("Content-Type", "application/json")
+      .postData(s"""{"queryString": "SELECT Id, Amount, Balance, InvoiceDate, InvoiceNumber, PaymentAmount, TargetDate, Status FROM Invoice WHERE AccountId = '$accountId' AND status = 'Posted'"}""")
+      .method("POST")
+      .asString
+      .body
+    val value = body
+      .pipe(read[InvoiceQueryResult](_))
+      .records
+      .sortBy(_.InvoiceDate)
+      .reverse
+      .take(2)
+    value match {
+      case neg :: pos :: Nil if neg.Amount == -invoiceAmount && pos.Amount == invoiceAmount => neg.InvoiceNumber
+    }
+  }
+
+  def transferToCreditBalance(invoiceNumber:String, invoiceAmount:BigDecimal, comment:String):Unit =
+    Http(s"$zuoraApiHost/v1/object/credit-balance-adjustment")
+      .header("Authorization", s"Bearer $accessToken")
+      .header("Content-Type", "application/json")
+      .postData(
+        s"""
+           |{
+           |  "Amount": $invoiceAmount,
+           |  "Comment": "$comment",
+           |  "SourceTransactionNumber": "$invoiceNumber",
+           |  "Type": "Increase"
+           |}
+           |""".stripMargin)
+      .method("POST")
+      .asString
+      .body
+      .pipe(body => read[RefundResult](body))
+
+  def applyCreditBalance(balancingInvoiceNumber:String, invoiceAmount:BigDecimal, comment:String) :Unit =
+    Http(s"$zuoraApiHost/v1/object/credit-balance-adjustment")
+      .header("Authorization", s"Bearer $accessToken")
+      .header("Content-Type", "application/json")
+      .postData(
+        s"""
+           |{
+           |  "Amount": $invoiceAmount,
+           |  "Comment": "$comment",
+           |  "SourceTransactionNumber": "$balancingInvoiceNumber",
+           |  "Type": "Decrease"
+           |}
+           |""".stripMargin)
+      .method("POST")
+      .asString
+      .body
+      .pipe(body => read[RefundResult](body))
+}

--- a/src/main/scala/com/gu/invoicing/refundErroneousPayment/Lambda.scala
+++ b/src/main/scala/com/gu/invoicing/refundErroneousPayment/Lambda.scala
@@ -1,12 +1,9 @@
 package com.gu.invoicing.refundErroneousPayment
 
-import Model._
-import Impl._
-import Program._
+import com.gu.invoicing.refundErroneousPayment.Model._
+import com.gu.invoicing.refundErroneousPayment.Program._
+
 import scala.util.chaining._
-import java.io.{InputStream, OutputStream}
-import java.nio.charset.Charset
-import java.util.logging.Logger
 
 /**
   * Run refund process as AWS lambda.

--- a/src/main/scala/com/gu/invoicing/refundErroneousPayment/Lambda.scala
+++ b/src/main/scala/com/gu/invoicing/refundErroneousPayment/Lambda.scala
@@ -1,0 +1,74 @@
+package com.gu.invoicing.refundErroneousPayment
+
+import Model._
+import Impl._
+import Program._
+import scala.util.chaining._
+import java.io.{InputStream, OutputStream}
+import java.nio.charset.Charset
+import java.util.logging.Logger
+
+/**
+  * Run refund process as AWS lambda.
+  * https://aws.amazon.com/blogs/compute/writing-aws-lambda-functions-in-scala/
+  *
+  * This lambda is used in API Gateway as Lambda Proxy Integration. The input format of the request is
+  * https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-input-format
+  *
+  * Input schema https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-input-format
+  *
+  * {
+  *   "resource": "Resource path",
+  *   "path": "Path parameter",
+  *   "httpMethod": "Incoming request's method name"
+  *   "headers": {String containing incoming request headers}
+  *   "multiValueHeaders": {List of strings containing incoming request headers}
+  *   "queryStringParameters": {query string parameters }
+  *   "multiValueQueryStringParameters": {List of query string parameters}
+  *   "pathParameters":  {path parameters}
+  *   "stageVariables": {Applicable stage variables}
+  *   "requestContext": {Request context, including authorizer-returned key-value pairs}
+  *   "body": "A JSON string of the request payload."
+  *   "isBase64Encoded": "A boolean flag to indicate if the applicable request payload is Base64-encode"
+  * }
+  *
+  * Output schema https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-output-format
+  *
+  * {
+  *   "isBase64Encoded": true|false,
+  *   "statusCode": httpStatusCode,
+  *   "headers": { "headerName": "headerValue", ... },
+  *   "multiValueHeaders": { "headerName": ["headerValue", "headerValue2", ...], ... },
+  *   "body": "..."
+  * }
+  *
+  * Note the key 'body'
+  *
+  *   "body": "A JSON string of the request payload."
+  *
+  * This is where the JSON body of the HTTP request is mapped to, however its value has to be a String of JSON,
+  * not actual JSON. This means to put JSON inside String we have to escape it
+  * https://stackoverflow.com/a/52240132/5205022
+  *
+  * Example test event for running the lambda from AWS Console:
+  * {
+  *   "body": "{\"accountId\":\"A123\",\"invoiceNumber\":\"INV123\",\"paymentId\":\"P123\",\"invoiceAmount\":0.1,\"comment\":"this is comment"}"
+  * }
+  */
+object Lambda {
+  def handleRequest(input: String): String = {
+    input
+      .pipe { read[ApiGatewayInput](_) }
+      .body
+      .pipe { read[RefundInput](_) }
+      .tap { info[RefundInput] }
+      .pipe { program }
+      .tap { info[RefundOutput] }
+      .pipe { refundOut =>
+        ApiGatewayOutput(200, write(refundOut))
+      }
+      .pipe { apiGatewayOut =>
+        write(apiGatewayOut)
+      }
+  }
+}

--- a/src/main/scala/com/gu/invoicing/refundErroneousPayment/Model.scala
+++ b/src/main/scala/com/gu/invoicing/refundErroneousPayment/Model.scala
@@ -1,0 +1,84 @@
+package com.gu.invoicing.refundErroneousPayment
+
+import com.gu.invoicing.common.JsonSupport
+
+import java.time.LocalDate
+
+/**
+  * Data models and JSON codecs
+  */
+object Model extends JsonSupport {
+
+  case class Config(clientId: String, clientSecret: String)
+
+  case class AccessToken(access_token: String)
+
+  case class Invoice(Id: String,
+                     InvoiceNumber: String,
+                     Amount: BigDecimal,
+                     Balance: BigDecimal,
+                     PaymentAmount: BigDecimal,
+                     TargetDate: LocalDate,
+                     InvoiceDate: LocalDate,
+                     Status: String)
+
+  case class InvoiceQueryResult(records: List[Invoice])
+
+  case class Metrics(balance: BigDecimal, totalInvoiceBalance: BigDecimal, creditBalance: BigDecimal)
+  case class Account(metrics: Metrics)
+
+  case class RefundResult(Id: String)
+
+  case class Refund(
+      RefundNumber: String,
+      GatewayState: String,
+      RefundDate: LocalDate,
+      ReasonCode: String,
+      GatewayResponse: String,
+      Amount: BigDecimal,
+      Comment: String,
+      Status: String,
+      Gateway: String,
+      MethodType: String,
+      GatewayResponseCode: String,
+      Id: String
+  )
+
+  implicit val configRW: ReadWriter[Config] = macroRW
+  implicit val accessTokenRW: ReadWriter[AccessToken] = macroRW
+  implicit val invoiceRW: ReadWriter[Invoice] = macroRW
+  implicit val invoiceQueryResultRW: ReadWriter[InvoiceQueryResult] = macroRW
+  implicit val refundResultRW: ReadWriter[RefundResult] = macroRW
+  implicit val refundRW: ReadWriter[Refund] = macroRW
+  implicit val metricsRW: ReadWriter[Metrics] = macroRW
+  implicit val accountRW: ReadWriter[Account] = macroRW
+
+  case class RefundInput(
+      accountId: String,
+      invoiceNumber: String,
+      paymentId: String,
+      invoiceAmount: BigDecimal,
+      comment: String,
+      message: String = "Start processing refund"
+  )
+
+  case class RefundOutput(
+      accountId: String,
+      paymentId: String,
+      invoiceAmount: BigDecimal,
+      invoiceNumber: String,
+      balancingInvoiceNumber: String,
+      message: String = "Successful refund",
+  )
+
+  // https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-input-format
+  case class ApiGatewayInput(body: String)
+
+  // https://aws.amazon.com/premiumsupport/knowledge-center/malformed-502-api-gateway/
+  case class ApiGatewayOutput(statusCode: Int, body: String)
+
+  implicit val refundInputRW: ReadWriter[RefundInput] = macroRW
+  implicit val refundOutputRW: ReadWriter[RefundOutput] = macroRW
+  implicit val awsBodyRW: ReadWriter[ApiGatewayInput] = macroRW
+  implicit val apiGatewayOutputRW: ReadWriter[ApiGatewayOutput] = macroRW
+}

--- a/src/main/scala/com/gu/invoicing/refundErroneousPayment/Model.scala
+++ b/src/main/scala/com/gu/invoicing/refundErroneousPayment/Model.scala
@@ -4,8 +4,7 @@ import com.gu.invoicing.common.JsonSupport
 
 import java.time.LocalDate
 
-/**
-  * Data models and JSON codecs
+/** Data models and JSON codecs
   */
 object Model extends JsonSupport {
 
@@ -13,18 +12,24 @@ object Model extends JsonSupport {
 
   case class AccessToken(access_token: String)
 
-  case class Invoice(Id: String,
-                     InvoiceNumber: String,
-                     Amount: BigDecimal,
-                     Balance: BigDecimal,
-                     PaymentAmount: BigDecimal,
-                     TargetDate: LocalDate,
-                     InvoiceDate: LocalDate,
-                     Status: String)
+  case class Invoice(
+      Id: String,
+      InvoiceNumber: String,
+      Amount: BigDecimal,
+      Balance: BigDecimal,
+      PaymentAmount: BigDecimal,
+      TargetDate: LocalDate,
+      InvoiceDate: LocalDate,
+      Status: String
+  )
 
   case class InvoiceQueryResult(records: List[Invoice])
 
-  case class Metrics(balance: BigDecimal, totalInvoiceBalance: BigDecimal, creditBalance: BigDecimal)
+  case class Metrics(
+      balance: BigDecimal,
+      totalInvoiceBalance: BigDecimal,
+      creditBalance: BigDecimal
+  )
   case class Account(metrics: Metrics)
 
   case class RefundResult(Id: String)
@@ -68,7 +73,7 @@ object Model extends JsonSupport {
       invoiceAmount: BigDecimal,
       invoiceNumber: String,
       balancingInvoiceNumber: String,
-      message: String = "Successful refund",
+      message: String = "Successful refund"
   )
 
   // https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-input-format

--- a/src/main/scala/com/gu/invoicing/refundErroneousPayment/Program.scala
+++ b/src/main/scala/com/gu/invoicing/refundErroneousPayment/Program.scala
@@ -3,7 +3,7 @@ package com.gu.invoicing.refundErroneousPayment
 import com.gu.invoicing.refundErroneousPayment.Impl._
 import com.gu.invoicing.refundErroneousPayment.Model._
 
-object Program extends App {
+object Program {
 
   def program(input: RefundInput): RefundOutput = {
     val RefundInput(accountId, invoiceNumber, paymentId, invoiceAmount, comment, _) = input

--- a/src/main/scala/com/gu/invoicing/refundErroneousPayment/Program.scala
+++ b/src/main/scala/com/gu/invoicing/refundErroneousPayment/Program.scala
@@ -1,0 +1,18 @@
+package com.gu.invoicing.refundErroneousPayment
+
+import com.gu.invoicing.refundErroneousPayment.Impl._
+import com.gu.invoicing.refundErroneousPayment.Model._
+
+object Program extends App {
+
+  def program(input: RefundInput): RefundOutput = {
+    val RefundInput(accountId, invoiceNumber, paymentId, invoiceAmount, comment, _) = input
+    val balancingInvoiceNumber = getBalancingInvoice(accountId, invoiceAmount)
+    transferToCreditBalance(balancingInvoiceNumber, invoiceAmount, comment)
+    val refundId = createRefundObject(invoiceAmount, paymentId, comment)
+    assert(getRefundStatus(refundId) == "Processed")
+    applyCreditBalance(invoiceNumber, invoiceAmount, comment)
+    assert(getAccountBalance(accountId) == 0)
+    RefundOutput(accountId, paymentId, invoiceAmount, invoiceNumber, balancingInvoiceNumber)
+  }
+}

--- a/src/main/scala/com/gu/invoicing/refundErroneousPayment/README.md
+++ b/src/main/scala/com/gu/invoicing/refundErroneousPayment/README.md
@@ -17,7 +17,7 @@ Content-Type: application/json
     "accountId": "A-S12345678",
     "invoiceNumber": "INV123456",
     "paymentId": "p123",
-    "invoiceAmount": 0.69
+    "invoiceAmount": 0.69,
     "comment": "???"
 }
 ```

--- a/src/main/scala/com/gu/invoicing/refundErroneousPayment/README.md
+++ b/src/main/scala/com/gu/invoicing/refundErroneousPayment/README.md
@@ -1,8 +1,11 @@
 # Refund Erroneous Payment
 
-This is for refunding in cases where a payment was inadvertently taken for an invoice.
+This is for refunding in cases where a payment was inadvertently taken for an invoice
+where there is also a balancing negative invoice on the same account.
 This could be, for instance, when a cancelled sub has been left with an amount outstanding
 and then a retry attempt is made to collect the outstanding amount.
+The script will ensure that there is no change in the invoice items or adjustments, meaning
+that the finance revenue schedules will not be affected.
 
 ### Example request
 

--- a/src/main/scala/com/gu/invoicing/refundErroneousPayment/README.md
+++ b/src/main/scala/com/gu/invoicing/refundErroneousPayment/README.md
@@ -1,0 +1,39 @@
+# Refund Erroneous Payment
+
+This is for refunding in cases where a payment was inadvertently taken for an invoice.
+This could be, for instance, when a cancelled sub has been left with an amount outstanding
+and then a retry attempt is made to collect the outstanding amount.
+
+### Example request
+
+Request
+
+```http
+POST /CODE/refund-erroneous-payment
+Host: <API ID>.execute-api.eu-west-1.amazonaws.com
+Content-Type: application/json
+
+{
+    "accountId": "A-S12345678",
+    "invoiceNumber": "INV123456",
+    "paymentId": "p123",
+    "invoiceAmount": 0.69
+    "comment": "???"
+}
+```
+
+Response
+
+```
+{
+    "accountId": "A123",
+    "paymentId": "P123",
+    "invoiceAmount": 0.69,
+    "invoiceNumber": "INV123456",
+    "balancingInvoiceNumber": "INV654321"
+}
+```
+
+### How to manually apply refund
+
+TODO


### PR DESCRIPTION
This adds a refunding endpoint specifically for cases where a payment was collected inadvertently and now needs to be refunded and the account balance corrected to avoid future collection attempts.

Tested in UAT.
