### PR TITLE
Key not found error handling

### DIFF
--- a/src/main/scala/com/gu/invoicing/refund/Impl.scala
+++ b/src/main/scala/com/gu/invoicing/refund/Impl.scala
@@ -213,7 +213,9 @@ object Impl {
       invoices: List[Invoice],
       itemsByInvoiceId: Map[String, List[InvoiceItem]]
   ): List[(String, Invoice, List[InvoiceItem])] = {
-    invoices.map(invoice => (invoice.Id, invoice, itemsByInvoiceId(invoice.Id)))
+    invoices.map(invoice => (invoice.Id, invoice, itemsByInvoiceId.get(invoice.Id))) collect {
+      case (invoiceId, invoice, Some(invoiceItems)) => (invoiceId, invoice, invoiceItems)
+    }
   }
 
   /** Select correct invoice to apply refund to */


### PR DESCRIPTION
## What does this change?

When running refunds for price-rise, we received timeout errors for 250 subscriptions, e.g.: `A-S01038760`. Looking through the logs, there was a `key not found` error on [this line](https://github.com/guardian/invoicing-api/blob/main/src/main/scala/com/gu/invoicing/refund/Impl.scala#L216), when trying to access the map via `itemsByInvoiceId(invoice.Id)`. 

 This is because we have not retrieved Invoice Items for all the customer's invoices. This is because the [invoice query](https://github.com/guardian/invoicing-api/blob/main/src/main/scala/com/gu/invoicing/refund/Impl.scala#L31) fetches all invoices from the customer's account, but the [invoice items query](https://github.com/guardian/invoicing-api/blob/main/src/main/scala/com/gu/invoicing/refund/Impl.scala#L54), only fetches the respective invoice items from the subscription we're dealing with. This means customer/billing account's with multiple subscriptions were failing. 

 Note: This may not be the reason all 250 subs were failing, still need to do more digging.

##  Testing

 Have tested on [this customer account](https://apisandbox.zuora.com/apps/CustomerAccount.do?method=view&id=8ad0823f81375b210181389c89d85bd7) in DEV environment with two newspaper subscriptions.