### PR TITLE
Changes to instruct Zuora to regenerate the invoice PDF if necessary for Australian users

### DIFF
--- a/src/main/scala/com/gu/invoicing/common/ZuoraAuth.scala
+++ b/src/main/scala/com/gu/invoicing/common/ZuoraAuth.scala
@@ -3,8 +3,10 @@ package com.gu.invoicing.common
 import java.lang.System.getenv
 import java.util.{Timer, TimerTask}
 import com.gu.invoicing.common.Retry._
+
 import scala.util.chaining._
 import scalaj.http.Http
+
 import scala.util.{Failure, Success}
 
 object ZuoraAuth extends JsonSupport {
@@ -21,6 +23,13 @@ object ZuoraAuth extends JsonSupport {
       case "DEV" | "CODE" => "https://rest.apisandbox.zuora.com";
       case "PROD"         => "https://rest.zuora.com"
     }
+
+  lazy val GNMAustralia_InvoiceTemplateID: String =
+    stage match {
+      case "DEV" => "2c92c0f85ecc47e5015ee7360d602757"
+      case "CODE" => "2c92c0f95ecc52d7015ee7348b9d4f61" // UAT Zuora
+      case "PROD" => "2c92a0fd5ecce80c015ee71028643020"
+    } // GNM Australia Pty Ltd
 
   /** Because list invoices is hit frequently JVM is kept warm and val access token would seem to
     * persist across lambda executions which meant the token would expire after one hour and because

--- a/src/main/scala/com/gu/invoicing/pdf/Cli.scala
+++ b/src/main/scala/com/gu/invoicing/pdf/Cli.scala
@@ -9,7 +9,7 @@ import com.gu.spy._
 
 /** Create environmental variables with Zuora OAuth credentials:
   *
-  * export STAGE = CODE export Config = { "clientId": "******", "clientSecret": "*****"}
+  * export Stage = CODE; export Config = { "clientId": "******", "clientSecret": "*****"}
   */
 object Cli {
   def main(args: Array[String]): Unit = {

--- a/src/main/scala/com/gu/invoicing/pdf/Impl.scala
+++ b/src/main/scala/com/gu/invoicing/pdf/Impl.scala
@@ -1,6 +1,6 @@
 package com.gu.invoicing.pdf
 
-import com.gu.invoicing.common.ZuoraAuth.{accessToken, zuoraApiHost}
+import com.gu.invoicing.common.ZuoraAuth.{accessToken, zuoraApiHost, GNMAustralia_InvoiceTemplateID}
 import com.gu.invoicing.pdf.Model._
 import com.gu.invoicing.common.Http
 import scala.util.chaining._
@@ -24,12 +24,12 @@ object Impl {
       .body
       .pipe(read[PutResponse](_))
 
-  def updateInvoiceTemplateId(accountId: String, invoiceTemplateId: String): PutResponse =
+  def setGNMAustraliaInvoiceTemplateId(accountId: String): PutResponse =
     Http(s"$zuoraApiHost/v1/object/account/$accountId")
       .header("Authorization", s"Bearer $accessToken")
       .method("put")
       .postData(
-        s"""{"InvoiceTemplateId":"$invoiceTemplateId"}"""
+        s"""{"InvoiceTemplateId":"$GNMAustralia_InvoiceTemplateID"}"""
       )
       .asString
       .body

--- a/src/main/scala/com/gu/invoicing/pdf/Impl.scala
+++ b/src/main/scala/com/gu/invoicing/pdf/Impl.scala
@@ -33,7 +33,7 @@ object Impl {
       )
       .asString
       .body
-      .pipe(read[PutResponse](_))
+      .pipe(read[PutResponse](_, true))
 
   def getAccount(accountId: String): Account =
     Http(s"$zuoraApiHost/v1/accounts/$accountId")

--- a/src/main/scala/com/gu/invoicing/pdf/Impl.scala
+++ b/src/main/scala/com/gu/invoicing/pdf/Impl.scala
@@ -36,7 +36,7 @@ object Impl {
       .pipe(read[PutResponse](_))
 
   def getAccount(accountId: String): Account =
-    Http(s"$zuoraApiHost/v1/object/account/$accountId")
+    Http(s"$zuoraApiHost/v1/accounts/$accountId")
       .header("Authorization", s"Bearer $accessToken")
       .asString
       .body

--- a/src/main/scala/com/gu/invoicing/pdf/Impl.scala
+++ b/src/main/scala/com/gu/invoicing/pdf/Impl.scala
@@ -16,24 +16,23 @@ object Impl {
   def regenerateInvoice(invoiceId: String): PutResponse =
     Http(s"$zuoraApiHost/v1/object/invoice/$invoiceId")
       .header("Authorization", s"Bearer $accessToken")
-      .method("put")
-      .postData(
+      .put(
         """{"RegenerateInvoicePDF":true}"""
       )
       .asString
       .body
       .pipe(read[PutResponse](_))
 
-  def setGNMAustraliaInvoiceTemplateId(accountId: String): PutResponse =
+  def setGNMAustraliaInvoiceTemplateId(accountId: String): PutResponse = {
     Http(s"$zuoraApiHost/v1/object/account/$accountId")
       .header("Authorization", s"Bearer $accessToken")
-      .method("put")
-      .postData(
+      .put(
         s"""{"InvoiceTemplateId":"$GNMAustralia_InvoiceTemplateID"}"""
       )
       .asString
       .body
-      .pipe(read[PutResponse](_, true))
+      .pipe(read[PutResponse](_))
+  }
 
   def getAccount(accountId: String): Account =
     Http(s"$zuoraApiHost/v1/accounts/$accountId")

--- a/src/main/scala/com/gu/invoicing/pdf/Impl.scala
+++ b/src/main/scala/com/gu/invoicing/pdf/Impl.scala
@@ -8,21 +8,41 @@ import scala.util.chaining._
 object Impl {
   def getInvoice(invoiceId: String): Invoice =
     Http(s"$zuoraApiHost/v1/object/invoice/$invoiceId")
-      .header("Authorization", s"Bearer ${accessToken}")
+      .header("Authorization", s"Bearer $accessToken")
       .asString
       .body
       .pipe(read[Invoice](_))
 
-  def getIdentityId(accountId: String): String =
-    Http(s"$zuoraApiHost/v1/accounts/$accountId")
-      .header("Authorization", s"Bearer ${accessToken}")
+  def regenerateInvoice(invoiceId: String): PutResponse =
+    Http(s"$zuoraApiHost/v1/object/invoice/$invoiceId")
+      .header("Authorization", s"Bearer $accessToken")
+      .method("put")
+      .postData(
+        """{"RegenerateInvoicePDF":true}"""
+      )
+      .asString
+      .body
+      .pipe(read[PutResponse](_))
+
+  def updateInvoiceTemplateId(accountId: String, invoiceTemplateId: String): PutResponse =
+    Http(s"$zuoraApiHost/v1/object/account/$accountId")
+      .header("Authorization", s"Bearer $accessToken")
+      .method("put")
+      .postData(
+        s"""{"InvoiceTemplateId":"$invoiceTemplateId"}"""
+      )
+      .asString
+      .body
+      .pipe(read[PutResponse](_))
+
+  def getAccount(accountId: String): Account =
+    Http(s"$zuoraApiHost/v1/object/account/$accountId")
+      .header("Authorization", s"Bearer $accessToken")
       .asString
       .body
       .pipe(read[Account](_))
-      .basicInfo
-      .IdentityId__c
 
-  val noCache = Map( // https://stackoverflow.com/a/2068407/5205022
+  val noCache: Map[String, String] = Map( // https://stackoverflow.com/a/2068407/5205022
     "Cache-Control" -> "no-cache, no-store, must-revalidate",
     "Pragma" -> "no-cache",
     "Expires" -> "0"

--- a/src/main/scala/com/gu/invoicing/pdf/Model.scala
+++ b/src/main/scala/com/gu/invoicing/pdf/Model.scala
@@ -14,7 +14,7 @@ object Model extends JsonSupport {
       Body: String /* Base64 encoded PDF */
   )
   case class BasicInfo(IdentityId__c: String)
-  case class Account(IdentityId__c: String, InvoiceTemplateId: String, Currency: Currency)
+  case class Account(IdentityId__c: String, InvoiceTemplateId: String, Currency: String)
   case class InvoiceFile(pdfFileUrl: String)
   case class InvoiceFiles(invoiceFiles: List[InvoiceFile])
   case class PutResponse(Success: Boolean, Id: String)

--- a/src/main/scala/com/gu/invoicing/pdf/Model.scala
+++ b/src/main/scala/com/gu/invoicing/pdf/Model.scala
@@ -2,18 +2,22 @@ package com.gu.invoicing.pdf
 
 import com.gu.invoicing.common.JsonSupport
 
+import java.util.Currency
+
 object Model extends JsonSupport {
   case class Config(clientId: String, clientSecret: String)
   case class AccessToken(access_token: String)
 
   case class Invoice(
+      Id: String,
       AccountId: String,
       Body: String /* Base64 encoded PDF */
   )
   case class BasicInfo(IdentityId__c: String)
-  case class Account(basicInfo: BasicInfo)
+  case class Account(IdentityId__c: String, InvoiceTemplateId: String, Currency: Currency)
   case class InvoiceFile(pdfFileUrl: String)
   case class InvoiceFiles(invoiceFiles: List[InvoiceFile])
+  case class PutResponse(Success: Boolean, Id: String)
 
   implicit val configRW: ReadWriter[Config] = macroRW
   implicit val accessTokenRW: ReadWriter[AccessToken] = macroRW
@@ -22,6 +26,7 @@ object Model extends JsonSupport {
   implicit val AccountRW: ReadWriter[Account] = macroRW
   implicit val InvoiceFileRW: ReadWriter[InvoiceFile] = macroRW
   implicit val InvoiceFileIdsRW: ReadWriter[InvoiceFiles] = macroRW
+  implicit val PutResponseRW: ReadWriter[PutResponse] = macroRW
 
   // https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-input-format
   case class InvoiceId(invoiceId: String)

--- a/src/main/scala/com/gu/invoicing/pdf/Model.scala
+++ b/src/main/scala/com/gu/invoicing/pdf/Model.scala
@@ -13,8 +13,10 @@ object Model extends JsonSupport {
       AccountId: String,
       Body: String /* Base64 encoded PDF */
   )
-  case class BasicInfo(IdentityId__c: String)
-  case class Account(IdentityId__c: String, InvoiceTemplateId: String, Currency: String)
+  case class BasicInfo(IdentityId__c: String, invoiceTemplateId: String)
+  case class BillingAndPayment(currency: String)
+  case class SoldToContact(country: String)
+  case class Account(basicInfo: BasicInfo, billingAndPayment: BillingAndPayment, soldToContact: SoldToContact)
   case class InvoiceFile(pdfFileUrl: String)
   case class InvoiceFiles(invoiceFiles: List[InvoiceFile])
   case class PutResponse(Success: Boolean, Id: String)
@@ -23,6 +25,8 @@ object Model extends JsonSupport {
   implicit val accessTokenRW: ReadWriter[AccessToken] = macroRW
   implicit val invoiceRW: ReadWriter[Invoice] = macroRW
   implicit val BasicInfoRW: ReadWriter[BasicInfo] = macroRW
+  implicit val BillingAndPaymentRW: ReadWriter[BillingAndPayment] = macroRW
+  implicit val SoldToContactRW: ReadWriter[SoldToContact] = macroRW
   implicit val AccountRW: ReadWriter[Account] = macroRW
   implicit val InvoiceFileRW: ReadWriter[InvoiceFile] = macroRW
   implicit val InvoiceFileIdsRW: ReadWriter[InvoiceFiles] = macroRW

--- a/src/main/scala/com/gu/invoicing/pdf/Program.scala
+++ b/src/main/scala/com/gu/invoicing/pdf/Program.scala
@@ -35,7 +35,7 @@ object Program {
   // If the currency is AUD but the invoice template ID is not the correct one then repair things by:
   // setting the correct invoice template ID, regenerating the PDF, and re-getting the PDF body.
   private def repairRequired(account: Account): Boolean = {
-    account.Currency == Currency.getInstance("AUD") &&
+    account.Currency == "AUD" &&
       account.InvoiceTemplateId != GNMAustralia_InvoiceTemplateID
   }
 

--- a/src/main/scala/com/gu/invoicing/pdf/Program.scala
+++ b/src/main/scala/com/gu/invoicing/pdf/Program.scala
@@ -13,10 +13,6 @@ object Program {
   def program(input: PdfInput): String = retryUnsafe {
     val PdfInput(invoiceId, identityId) = input
     val invoice = getInvoice(invoiceId)
-    assert(
-      invoiceId == invoice.Id,
-      s"Returned invoice id: ${invoice.Id} does not match requested invoice id: $invoiceId"
-    )
     val account = getAccount(invoice.AccountId)
     assert(
       identityId == account.basicInfo.IdentityId__c,

--- a/src/main/scala/com/gu/invoicing/pdf/Program.scala
+++ b/src/main/scala/com/gu/invoicing/pdf/Program.scala
@@ -3,12 +3,11 @@ package com.gu.invoicing.pdf
 import com.gu.invoicing.pdf.Model._
 import com.gu.invoicing.pdf.Impl._
 import com.gu.invoicing.common.Retry._
+import com.gu.invoicing.common.ZuoraAuth.{GNMAustralia_InvoiceTemplateID}
 
-import java.util.Currency
+import java.lang.System.getenv
 
 object Program {
-
-  private val GNMAustralia_InvoiceTemplateID = "2c92a0fd5ecce80c015ee71028643020" // GNM Australia Pty Ltd
 
   /** Main business logic */
   def program(input: PdfInput): String = retryUnsafe {
@@ -24,7 +23,7 @@ object Program {
       s"Requested invoice id: $invoiceId appears to belong to different identity: ${account.basicInfo.IdentityId__c}"
     )
     if (repairRequired(account)) {
-      updateInvoiceTemplateId(invoice.AccountId, GNMAustralia_InvoiceTemplateID)
+      setGNMAustraliaInvoiceTemplateId(invoice.AccountId)
       regenerateInvoice(invoice.Id)
       getInvoice(invoice.Id).Body
     } else {

--- a/src/main/scala/com/gu/invoicing/pdf/Program.scala
+++ b/src/main/scala/com/gu/invoicing/pdf/Program.scala
@@ -20,8 +20,8 @@ object Program {
     )
     val account = getAccount(invoice.AccountId)
     assert(
-      identityId == account.IdentityId__c,
-      s"Requested invoice id: $invoiceId appears to belong to different identity: ${account.IdentityId__c}"
+      identityId == account.basicInfo.IdentityId__c,
+      s"Requested invoice id: $invoiceId appears to belong to different identity: ${account.basicInfo.IdentityId__c}"
     )
     if (repairRequired(account)) {
       updateInvoiceTemplateId(invoice.AccountId, GNMAustralia_InvoiceTemplateID)
@@ -32,11 +32,12 @@ object Program {
     }
   }
 
-  // If the currency is AUD but the invoice template ID is not the correct one then repair things by:
-  // setting the correct invoice template ID, regenerating the PDF, and re-getting the PDF body.
+  // If the sold to country is Australia, the currency is AUD but the invoice template ID is not the correct one,
+  // then repair things by setting the correct invoice template ID, regenerating the PDF, and re-getting the PDF body.
   private def repairRequired(account: Account): Boolean = {
-    account.Currency == "AUD" &&
-      account.InvoiceTemplateId != GNMAustralia_InvoiceTemplateID
+    account.soldToContact.country == "Australia" &&
+    account.billingAndPayment.currency == "AUD" &&
+      account.basicInfo.invoiceTemplateId != GNMAustralia_InvoiceTemplateID
   }
 
 }


### PR DESCRIPTION
## What does this change?

Changes to instruct Zuora to regenerate the invoice PDF if it has been using the wrong template ID in the past.

This action is too impractical to backfill eagerly as it would require updating ~54K accounts and ~226K invoices, and the regeneration of the PDF takes about 5 seconds. Only about 1000 customers out of that 55,000 will ever download an invoice, so I've decided it's best to do the regeneration on-demand rather than backfilling. I believe this API services Salesforce as well as Manage My Account.

## How to test

1. Have an AUD subscription with an invoice generated via the UK company Invoice Template.
2. Log in to the account for that subscription and visit the [invoice download page](url) within Manage My Account
3. Click to download the invoice - it should take a long time ~ 20 seconds to complete.
4. The template ID within the customer's Zuora Billing Account will now be the Australian company.
5. The downloaded invoice PDF should contain details of the Australian company not the UK company.

## How can we measure success?

No errors in logs. Tested in DEV & CODE.

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->
Slow responses could time out. Metrics onthe Escalations from the Call Centre should hopefully report this.

## [Trello](https://trello.com/c/LFp15ME6)

## Images

Example UK template PDF:
<img width="555" alt="Screenshot 2022-10-05 at 17 16 56" src="https://user-images.githubusercontent.com/1515970/196130423-11e26427-fd1d-4331-97c4-59102a91768a.png">

Example Australian template PDF:
<img width="570" alt="Screenshot 2022-10-05 at 17 17 09" src="https://user-images.githubusercontent.com/1515970/196130447-8802fc77-7a15-45d0-830f-77ffb74a4772.png">

