### PR TITLE
Allow clients to specify whether invoices should be adjusted after a refund

### DIFF
--- a/src/main/scala/com/gu/invoicing/refund/Model.scala
+++ b/src/main/scala/com/gu/invoicing/refund/Model.scala
@@ -111,6 +111,7 @@ object Model extends JsonSupport {
   case class RefundInput(
       subscriptionName: String,
       refund: BigDecimal,
+      adjustInvoices: Boolean = true,
       guid: String = UUID.randomUUID().toString,
       message: String = "Start processing refund"
   )

--- a/src/main/scala/com/gu/invoicing/refund/Program.scala
+++ b/src/main/scala/com/gu/invoicing/refund/Program.scala
@@ -14,19 +14,19 @@ import scala.util.chaining._
   */
 object Program {
   def program(input: RefundInput): RefundOutput = {
-    val RefundInput(subscriptionName, refund, guid, _) = input
+    val RefundInput(subscriptionName, refund, adjustInvoices, guid, _) = input
 
     val subscription = getSubscription(subscriptionName) tap { subscription =>
       s"$subscriptionName should be retrieved" assert (subscription.subscriptionNumber == subscriptionName)
     }
     val balanceBeforeRefund = getAccountBalance(subscription.accountId) tap { balanceBeforeRefund =>
-      s"$balanceBeforeRefund should be recorded" assert (true)
+      s"$balanceBeforeRefund should be recorded" assert true
     }
     val invoices = getInvoices(subscription.accountId) tap { invoices =>
-      s"$subscriptionName should have at least one invoice" assert (invoices.nonEmpty)
+      s"$subscriptionName should have at least one invoice" assert invoices.nonEmpty
     }
     val itemsByInvoiceId = getItemsByInvoice(subscriptionName) tap { itemsByInvoiceId =>
-      s"$subscriptionName should have at least one invoice item" assert (itemsByInvoiceId.nonEmpty)
+      s"$subscriptionName should have at least one invoice item" assert itemsByInvoiceId.nonEmpty
     }
 
     val (invoiceId, _, items) = decideRelevantInvoice(invoices, itemsByInvoiceId) tap {
@@ -34,10 +34,10 @@ object Program {
         s"$invoice should be at least posted and not negative" assert (invoice.Amount > 0.0 && invoice.Status == "Posted")
     }
     val itemAdjustments = getInvoiceItemAdjustments(invoiceId) tap { _ =>
-      s"Invoice items of $invoiceId should be retrieved" assert (true)
+      s"Invoice items of $invoiceId should be retrieved" assert true
     }
     val Some(paymentId) = getInvoicePaymentId(invoiceId) tap { paymentId =>
-      s"$invoiceId should have a payment" assert (paymentId.isDefined)
+      s"$invoiceId should have a payment" assert paymentId.isDefined
     }
     val adjustmentsUnrounded = spreadRefundAcrossItems(items, itemAdjustments, refund, guid) tap {
       adjustmentsUnrounded =>
@@ -52,16 +52,19 @@ object Program {
     }
 
     val refundId = createRefundObject(refund, paymentId, guid) tap { _ =>
-      s"Refund object for $paymentId should be created" assert (true)
+      s"Refund object for $paymentId should be created" assert true
     }
-    val _ = getRefundStatus(refundId) tap { refundStatus =>
+    getRefundStatus(refundId) tap { refundStatus =>
       s"$refundId in amount of $refund should be processed" assert (refundStatus == "Processed")
     }
-    val result = applyRefundOverItemAdjustments(adjustmentsRounded) tap { adjustments =>
-      s"All $adjustments should be successful" assert (adjustments.forall(_.Success))
-    }
-    val balanceAfterRefund = getAccountBalance(subscription.accountId) tap { balanceAfterRefund =>
-      s"${subscription.accountId} balance should not change after refund" assert (balanceBeforeRefund == balanceAfterRefund)
+
+    if (adjustInvoices) {
+      applyRefundOverItemAdjustments(adjustmentsRounded) tap { adjustments =>
+        s"All $adjustments should be successful" assert adjustments.forall(_.Success)
+      }
+      getAccountBalance(subscription.accountId) tap { balanceAfterRefund =>
+        s"${subscription.accountId} balance should not change after refund" assert (balanceBeforeRefund == balanceAfterRefund)
+      }
     }
 
     RefundOutput(subscriptionName, refund, invoiceId, paymentId, adjustmentsRounded, guid)

--- a/src/test/scala/com/gu/invoicing/refund/InputSerialisationSuite.scala
+++ b/src/test/scala/com/gu/invoicing/refund/InputSerialisationSuite.scala
@@ -1,0 +1,16 @@
+package com.gu.invoicing.refund
+
+import com.gu.invoicing.refund.Model.RefundInput
+import Model._
+
+class InputSerialisationSuite extends munit.FunSuite {
+  test("Serialisation works when adjustInvoices parameter is omitted") {
+    val inputString = """{"subscriptionName": "A-S00045160","refund": 0.1}"""
+    assertEquals(read[RefundInput](inputString).adjustInvoices, true)
+  }
+
+  test("Serialisation works when adjustInvoices parameter is present") {
+    val inputString = """{"subscriptionName": "A-S00045160","refund": 0.1, "adjustInvoices": false}"""
+    assertEquals(read[RefundInput](inputString).adjustInvoices, false)
+  }
+}


### PR DESCRIPTION


## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
