### PR TITLE
Remove the DEV environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Invoice management for supporters
 
 * Riff-Raff project: `support:invoicing-api`
 * Artifact bucket: `membership-dist/support/PROD/invoicing-api/invoicing-api.jar`
-* Zuora API User: `invoicing-api+uat@guardian.co.uk`
+* Zuora API User: `invoicing-api+dev@guardian.co.uk`
 * Parameter store: `/invoicing-api/${Stage}/config`
 
 ## Structure

--- a/build.sbt
+++ b/build.sbt
@@ -30,7 +30,7 @@ lazy val root = (project in file("."))
   )
 
 lazy val deployTo =
-  inputKey[Unit]("Directly update AWS lambda code from DEV instead of via RiffRaff for faster feedback loop")
+  inputKey[Unit]("Directly update AWS lambda code from your local machine instead of via RiffRaff for faster feedback loop")
 
 deployTo := {
   import scala.sys.process._

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -7,7 +7,6 @@ Parameters:
     Description: Stage name
     Type: String
     AllowedValues:
-      - DEV
       - CODE
       - PROD
     Default: CODE

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -3,7 +3,6 @@ stacks:
 regions:
   - eu-west-1
 allowedStages:
-  - DEV
   - CODE
   - PROD
 deployments:

--- a/src/main/scala/com/gu/invoicing/common/ZuoraAuth.scala
+++ b/src/main/scala/com/gu/invoicing/common/ZuoraAuth.scala
@@ -20,14 +20,13 @@ object ZuoraAuth extends JsonSupport {
 
   lazy val zuoraApiHost: String =
     stage match {
-      case "DEV" | "CODE" => "https://rest.apisandbox.zuora.com";
+      case "CODE" => "https://rest.apisandbox.zuora.com";
       case "PROD" => "https://rest.zuora.com"
     }
 
   lazy val GNMAustralia_InvoiceTemplateID: String =
     stage match {
-      case "DEV" => "2c92c0f85ecc47e5015ee7360d602757"
-      case "CODE" => "2c92c0f95ecc52d7015ee7348b9d4f61" // UAT Zuora
+      case "CODE" => "2c92c0f85ecc47e5015ee7360d602757"
       case "PROD" => "2c92a0fd5ecce80c015ee71028643020"
     } // GNM Australia Pty Ltd
 

--- a/src/main/scala/com/gu/invoicing/invoice/README.md
+++ b/src/main/scala/com/gu/invoicing/invoice/README.md
@@ -38,7 +38,7 @@ Authorization: ********
 
 #### With CLI 
 
-1. Get invoicing-api+uat@guardian.co.uk Zuora OAuth client credentials
+1. Get invoicing-api+dev@guardian.co.uk Zuora OAuth client credentials
 1. Follow docs in `Cli.scala` and create `Stage` and `Config` environmental variables
 1. Performance can be estimated with something like 
     ```

--- a/src/main/scala/com/gu/invoicing/nextinvoicedate/README.md
+++ b/src/main/scala/com/gu/invoicing/nextinvoicedate/README.md
@@ -36,7 +36,7 @@ otherwise
 
 #### With CLI 
 
-1. Get invoicing-api+uat@guardian.co.uk Zuora OAuth client credentials
+1. Get invoicing-api+dev@guardian.co.uk Zuora OAuth client credentials
 1. Follow docs in `Cli.scala` and create `Stage` and `Config` environmental variables
 1. Simply run something like
     ```

--- a/src/main/scala/com/gu/invoicing/pdf/README.md
+++ b/src/main/scala/com/gu/invoicing/pdf/README.md
@@ -29,7 +29,7 @@ Content-Type: application/pdf;charset=UTF-8
 
 #### With CLI 
 
-1. Get invoicing-api+uat@guardian.co.uk Zuora OAuth client credentials
+1. Get invoicing-api+dev@guardian.co.uk Zuora OAuth client credentials
 1. Follow docs in `Cli.scala` and create `Stage` and `Config` environmental variables
 1. Simply run something like
     ```

--- a/src/main/scala/com/gu/invoicing/preview/README.md
+++ b/src/main/scala/com/gu/invoicing/preview/README.md
@@ -67,7 +67,7 @@ otherwise
 
 #### With CLI 
 
-1. Get invoicing-api+uat@guardian.co.uk Zuora OAuth client credentials
+1. Get invoicing-api+dev@guardian.co.uk Zuora OAuth client credentials
 1. Follow docs in `Cli.scala` and create `Stage` and `Config` environmental variables
 1. Simply run something like
     ```


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This PR is part of the work to rationalise the supporter revenue code environments described [in this document](https://docs.google.com/document/d/1wg1kMk7U7ht3AmPpsPUimtz1FkVbu5BWjijjme2598s/edit#heading=h.e8xht7lakf3b)

Specifically it is removing the DEV environment so that the lambdas now only exist in CODE or PROD as per this diagram:

![Supporter Revenue Environments(4)](https://github.com/guardian/invoicing-api/assets/181371/f0999638-7e48-4a0f-b6ec-b28869c96cc5)

I have also updated the CODE config in parameter store to be the same as the DEV config using these commands:

```shell
path=/invoicing-api/DEV

declare -a params=$(aws ssm get-parameters-by-path --path $path --recursive --max-items 50 | jq -r ".Parameters | .[] | .Name") 

for param in ${params[@]}; do
    paramValue=$(aws ssm get-parameter --with-decryption --name $param | jq -r ".Parameter.Value")    
    echo "Parameter $param has value $paramValue"   
    newName="${param/DEV/CODE}"
    echo "Parameter $newName will be updated with the value $paramValue"
    aws ssm put-parameter --name $newName --value "$paramValue" --type SecureString --overwrite > /dev/null
done
```