### PR TITLE
use updated sandbox zuora config for CODE

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -11,6 +11,13 @@ Parameters:
       - PROD
     Default: CODE
 
+Mappings:
+  StageMap:
+    PROD:
+      ConfigVersion: 1
+    CODE:
+      ConfigVersion: 2
+
 Conditions:
   IsProd: !Equals [!Ref "Stage", "PROD"]
 
@@ -155,7 +162,10 @@ Resources:
       Environment:
         Variables:
           Stage: !Ref Stage
-          Config: !Sub '{{resolve:ssm:/invoicing-api/${Stage}/config:1}}'
+          Config:
+            !Sub
+            - '{{resolve:ssm:/invoicing-api/${Stage}/config:${Version}}'
+            - Version: !FindInMap [StageMap, !Ref Stage, ConfigVersion]
       Role: !GetAtt InvoicingLambdaRole.Arn
       MemorySize: 3008
       Runtime: java11
@@ -175,7 +185,10 @@ Resources:
       Environment:
         Variables:
           Stage: !Ref Stage
-          Config: !Sub '{{resolve:ssm:/invoicing-api/${Stage}/config:1}}'
+          Config:
+            !Sub
+            - '{{resolve:ssm:/invoicing-api/${Stage}/config:${Version}}'
+            - Version: !FindInMap [StageMap, !Ref Stage, ConfigVersion]
       Role: !GetAtt InvoicingLambdaRole.Arn
       MemorySize: 3008
       Runtime: java11
@@ -195,7 +208,10 @@ Resources:
       Environment:
         Variables:
           Stage: !Ref Stage
-          Config: !Sub '{{resolve:ssm:/invoicing-api/${Stage}/config:1}}'
+          Config:
+            !Sub
+            - '{{resolve:ssm:/invoicing-api/${Stage}/config:${Version}}'
+            - Version: !FindInMap [StageMap, !Ref Stage, ConfigVersion]
       Role: !GetAtt InvoicingLambdaRole.Arn
       MemorySize: 3008
       Runtime: java11
@@ -215,7 +231,10 @@ Resources:
       Environment:
         Variables:
           Stage: !Ref Stage
-          Config: !Sub '{{resolve:ssm:/invoicing-api/${Stage}/config:1}}'
+          Config:
+            !Sub
+            - '{{resolve:ssm:/invoicing-api/${Stage}/config:${Version}}'
+            - Version: !FindInMap [StageMap, !Ref Stage, ConfigVersion]
       Role: !GetAtt InvoicingLambdaRole.Arn
       MemorySize: 3008
       Runtime: java11
@@ -235,7 +254,10 @@ Resources:
       Environment:
         Variables:
           Stage: !Ref Stage
-          Config: !Sub '{{resolve:ssm:/invoicing-api/${Stage}/config:1}}'
+          Config:
+            !Sub
+            - '{{resolve:ssm:/invoicing-api/${Stage}/config:${Version}}'
+            - Version: !FindInMap [StageMap, !Ref Stage, ConfigVersion]
       Role: !GetAtt InvoicingLambdaRole.Arn
       MemorySize: 3008
       Runtime: java11
@@ -255,7 +277,10 @@ Resources:
       Environment:
         Variables:
           Stage: !Ref Stage
-          Config: !Sub '{{resolve:ssm:/invoicing-api/${Stage}/config:1}}'
+          Config:
+            !Sub
+            - '{{resolve:ssm:/invoicing-api/${Stage}/config:${Version}}'
+            - Version: !FindInMap [StageMap, !Ref Stage, ConfigVersion]
       Role: !GetAtt InvoicingLambdaRole.Arn
       MemorySize: 3008
       Runtime: java11

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -164,7 +164,7 @@ Resources:
           Stage: !Ref Stage
           Config:
             !Sub
-            - '{{resolve:ssm:/invoicing-api/${Stage}/config:${Version}}'
+            - '{{resolve:ssm:/invoicing-api/${Stage}/config:${Version}}}'
             - Version: !FindInMap [StageMap, !Ref Stage, ConfigVersion]
       Role: !GetAtt InvoicingLambdaRole.Arn
       MemorySize: 3008
@@ -187,7 +187,7 @@ Resources:
           Stage: !Ref Stage
           Config:
             !Sub
-            - '{{resolve:ssm:/invoicing-api/${Stage}/config:${Version}}'
+            - '{{resolve:ssm:/invoicing-api/${Stage}/config:${Version}}}'
             - Version: !FindInMap [StageMap, !Ref Stage, ConfigVersion]
       Role: !GetAtt InvoicingLambdaRole.Arn
       MemorySize: 3008
@@ -210,7 +210,7 @@ Resources:
           Stage: !Ref Stage
           Config:
             !Sub
-            - '{{resolve:ssm:/invoicing-api/${Stage}/config:${Version}}'
+            - '{{resolve:ssm:/invoicing-api/${Stage}/config:${Version}}}'
             - Version: !FindInMap [StageMap, !Ref Stage, ConfigVersion]
       Role: !GetAtt InvoicingLambdaRole.Arn
       MemorySize: 3008
@@ -233,7 +233,7 @@ Resources:
           Stage: !Ref Stage
           Config:
             !Sub
-            - '{{resolve:ssm:/invoicing-api/${Stage}/config:${Version}}'
+            - '{{resolve:ssm:/invoicing-api/${Stage}/config:${Version}}}'
             - Version: !FindInMap [StageMap, !Ref Stage, ConfigVersion]
       Role: !GetAtt InvoicingLambdaRole.Arn
       MemorySize: 3008
@@ -256,7 +256,7 @@ Resources:
           Stage: !Ref Stage
           Config:
             !Sub
-            - '{{resolve:ssm:/invoicing-api/${Stage}/config:${Version}}'
+            - '{{resolve:ssm:/invoicing-api/${Stage}/config:${Version}}}'
             - Version: !FindInMap [StageMap, !Ref Stage, ConfigVersion]
       Role: !GetAtt InvoicingLambdaRole.Arn
       MemorySize: 3008
@@ -279,7 +279,7 @@ Resources:
           Stage: !Ref Stage
           Config:
             !Sub
-            - '{{resolve:ssm:/invoicing-api/${Stage}/config:${Version}}'
+            - '{{resolve:ssm:/invoicing-api/${Stage}/config:${Version}}}'
             - Version: !FindInMap [StageMap, !Ref Stage, ConfigVersion]
       Role: !GetAtt InvoicingLambdaRole.Arn
       MemorySize: 3008


### PR DESCRIPTION
We were having trouble with Auth not working for these lambdas to zuora, even after updating in SSM.

Having looked into it, the version of the parameter in SSM was hard coded in the CFN as `1`, meaning the updated one was not used.
![image](https://github.com/guardian/invoicing-api/assets/7304387/c053fda6-a640-4dd6-951c-22139e1565d2)
https://eu-west-1.console.aws.amazon.com/systems-manager/parameters/invoicing-api/CODE/config/description?region=eu-west-1&tab=Table

This PR updates the CFN to use the version specified.


I know it has been a trend in the past, but overall it seems like a faff to use CFN dynamic references for config, rather than just pulling it directly from the service in the code.  If it it pulled in startup, it might be slightly slower, but it means it's easier to run it locally, and everything is always up to date.  I'd be interested to know if there are strong arguments in favour of this method.