### PR TITLE
Handle refunds where there is more than one invoice on the same day

### DIFF
--- a/src/main/scala/com/gu/invoicing/refund/Impl.scala
+++ b/src/main/scala/com/gu/invoicing/refund/Impl.scala
@@ -213,12 +213,13 @@ object Impl {
 
   /** Select correct invoice to apply refund to */
   def decideRelevantInvoice(
+      refund: BigDecimal,
       invoices: List[Invoice],
       itemsByInvoiceId: Map[String, List[InvoiceItem]],
   ): (String, Invoice, List[InvoiceItem]) = {
     joinInvoiceWithInvoiceItemsOnInvoiceIdKey(invoices, itemsByInvoiceId).iterator
       .filter({ case (_, invoice, _) => invoice.Status == "Posted" })
-      .filter({ case (_, invoice, _) => invoice.Amount > 0 })
+      .filter({ case (_, invoice, _) => invoice.Amount >= refund })
       .maxBy({ case (_, invoice, _) => invoice.TargetDate })
   }
 

--- a/src/main/scala/com/gu/invoicing/refund/Program.scala
+++ b/src/main/scala/com/gu/invoicing/refund/Program.scala
@@ -33,10 +33,13 @@ object Program {
     }
     System.out.println("Successfully got InvoiceItems")
 
-    val (invoiceId, invoice, items) = decideRelevantInvoice(invoices, itemsByInvoiceId) tap { case (_, invoice, _) =>
-      s"$invoice should be at least posted and not negative" assert (invoice.Amount > 0.0 && invoice.Status == "Posted")
+    val (invoiceId, invoice, items) = decideRelevantInvoice(refund, invoices, itemsByInvoiceId) tap {
+      case (_, invoice, _) =>
+        s"$invoice should be posted and have an amount >= the refund value" assert (
+          invoice.Amount >= refund && invoice.Status == "Posted"
+        )
     }
-    System.out.println(s"Invoice $invoice is posted and not negative")
+    System.out.println(s"Invoice $invoice is posted and has an amount >= the refund value")
 
     val itemAdjustments = getInvoiceItemAdjustments(invoiceId) tap { _ =>
       s"Invoice items of $invoiceId should be retrieved" assert true

--- a/src/test/resources/refund/invoice-items-2.json
+++ b/src/test/resources/refund/invoice-items-2.json
@@ -1,0 +1,84 @@
+{
+  "size": 6,
+  "records": [
+    {
+      "ChargeDate": "2023-11-13T16:22:13.000+00:00",
+      "TaxAmount": 0,
+      "SubscriptionNumber": "A-S00721653",
+      "ProductName": "Supporter Plus",
+      "ServiceEndDate": "2024-11-12",
+      "ServiceStartDate": "2023-11-13",
+      "ChargeName": "Subscription",
+      "Id": "8ad087d28bc80bf2018bc97d99ef6e9a",
+      "InvoiceId": "8ad087d28bc80bf2018bc97d99e36e95",
+      "ChargeAmount": -120,
+      "ChargeNumber": "C-01242100"
+    },
+    {
+      "ChargeDate": "2023-11-13T16:22:13.000+00:00",
+      "TaxAmount": 0,
+      "SubscriptionNumber": "A-S00721653",
+      "ProductName": "Supporter Plus",
+      "ServiceEndDate": "2024-11-12",
+      "ServiceStartDate": "2023-11-13",
+      "ChargeName": "Contribution",
+      "Id": "8ad087d28bc80bf2018bc97d99ef6e9b",
+      "InvoiceId": "8ad087d28bc80bf2018bc97d99e36e95",
+      "ChargeAmount": 0,
+      "ChargeNumber": "C-01242101"
+    },
+    {
+      "ChargeDate": "2023-11-13T15:19:44.000+00:00",
+      "TaxAmount": 0,
+      "SubscriptionNumber": "A-S00721653",
+      "ProductName": "Contributor",
+      "ServiceEndDate": "2024-11-12",
+      "ServiceStartDate": "2023-11-13",
+      "ChargeName": "Contribution",
+      "Id": "8ad08ae28bc80bfe018bc944644d3134",
+      "InvoiceId": "8ad08ae28bc80bfe018bc94464403132",
+      "ChargeAmount": 50,
+      "ChargeNumber": "C-01242008"
+    },
+    {
+      "ChargeDate": "2023-11-13T16:21:28.000+00:00",
+      "TaxAmount": 0,
+      "SubscriptionNumber": "A-S00721653",
+      "ProductName": "Supporter Plus",
+      "ServiceEndDate": "2024-11-12",
+      "ServiceStartDate": "2023-11-13",
+      "ChargeName": "Contribution",
+      "Id": "8ad093788bc82157018bc97ce7557025",
+      "InvoiceId": "8ad093788bc82157018bc97ce7457024",
+      "ChargeAmount": 0,
+      "ChargeNumber": "C-01242101"
+    },
+    {
+      "ChargeDate": "2023-11-13T16:21:28.000+00:00",
+      "TaxAmount": 0,
+      "SubscriptionNumber": "A-S00721653",
+      "ProductName": "Contributor",
+      "ServiceEndDate": "2024-11-12",
+      "ServiceStartDate": "2023-11-13",
+      "ChargeName": "Contribution",
+      "Id": "8ad093788bc82157018bc97ce7557026",
+      "InvoiceId": "8ad093788bc82157018bc97ce7457024",
+      "ChargeAmount": -50,
+      "ChargeNumber": "C-01242008"
+    },
+    {
+      "ChargeDate": "2023-11-13T16:21:28.000+00:00",
+      "TaxAmount": 0,
+      "SubscriptionNumber": "A-S00721653",
+      "ProductName": "Supporter Plus",
+      "ServiceEndDate": "2024-11-12",
+      "ServiceStartDate": "2023-11-13",
+      "ChargeName": "Subscription",
+      "Id": "8ad093788bc82157018bc97ce7557027",
+      "InvoiceId": "8ad093788bc82157018bc97ce7457024",
+      "ChargeAmount": 120,
+      "ChargeNumber": "C-01242100"
+    }
+  ],
+  "done": true
+}

--- a/src/test/resources/refund/invoices-2.json
+++ b/src/test/resources/refund/invoices-2.json
@@ -1,0 +1,36 @@
+{
+  "size": 3,
+  "records": [
+    {
+      "Status": "Posted",
+      "TargetDate": "2023-11-13",
+      "Amount": -120,
+      "Id": "8ad087d28bc80bf2018bc97d99e36e95",
+      "InvoiceDate": "2023-11-13",
+      "InvoiceNumber": "INV01279583",
+      "PaymentAmount": 0,
+      "Balance": -120
+    },
+    {
+      "Status": "Posted",
+      "TargetDate": "2023-11-13",
+      "Amount": 50,
+      "Id": "8ad08ae28bc80bfe018bc94464403132",
+      "InvoiceDate": "2023-11-13",
+      "InvoiceNumber": "INV01279549",
+      "PaymentAmount": 50,
+      "Balance": 0
+    },
+    {
+      "Status": "Posted",
+      "TargetDate": "2023-11-13",
+      "Amount": 70,
+      "Id": "8ad093788bc82157018bc97ce7457024",
+      "InvoiceDate": "2023-11-13",
+      "InvoiceNumber": "INV01279582",
+      "PaymentAmount": 70,
+      "Balance": 0
+    }
+  ],
+  "done": true
+}


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
The invoicing-api currently has an issue with refunding subscriptions where there is more than one invoice on the same day.

This can happen during a product switch, for instance, if I take out an annual recurring contribution for £30 then decide that actually I want supporter plus so that I can access the app and immediately switch to annual S+ at a cost of £95/year. In Zuora my subscription will now have two associated invoices dated today one for £30 and one for £65 (30 + 65 = total cost of the S+ sub).

If I then cancel within 14 days we will attempt a refund of the £65 paid at switch using the invoicing-api and that will pick the most recent positive posted invoice on the account to carry out the refund on.

However the 'most recent' check is only to a day level so which of the invoices it chooses is undefined - in practice it seems to be the first one which in this example is the wrong one and does not have enough money on it to enable the refund.

This PR changes the behaviour which picks the appropriate invoice to run the refund against by ensuring that the invoice which we pick has an amount at least equal to the amount we are trying to refund.