### PR TITLE
Set Adjustment Date to current date, not date of original charge

### DIFF
--- a/src/main/scala/com/gu/invoicing/refund/Impl.scala
+++ b/src/main/scala/com/gu/invoicing/refund/Impl.scala
@@ -2,7 +2,7 @@ package com.gu.invoicing.refund
 
 import com.gu.invoicing.common.ZuoraAuth.{accessToken, zuoraApiHost}
 
-import java.time.LocalDate
+import java.time.{LocalDate, ZoneId}
 import com.gu.invoicing.common.Http
 
 import scala.annotation.tailrec
@@ -120,7 +120,7 @@ object Impl {
       val chargeAmountToRefund = invoiceItem.ChargeAmount.min(amountToRefund)
       val chargeAdjustment = List(
         InvoiceItemAdjustmentWrite(
-          LocalDate.now(),
+          LocalDate.now(ZoneId.of("Europe/London")),
           chargeAmountToRefund,
           refundGuid,
           invoiceItem.InvoiceId,
@@ -148,7 +148,7 @@ object Impl {
 
           List(
             InvoiceItemAdjustmentWrite(
-              LocalDate.now(),
+              LocalDate.now(ZoneId.of("Europe/London")),
               taxAmountToRefund,
               refundGuid,
               invoiceItem.InvoiceId,

--- a/src/main/scala/com/gu/invoicing/refund/Impl.scala
+++ b/src/main/scala/com/gu/invoicing/refund/Impl.scala
@@ -120,7 +120,7 @@ object Impl {
       val chargeAmountToRefund = invoiceItem.ChargeAmount.min(amountToRefund)
       val chargeAdjustment = List(
         InvoiceItemAdjustmentWrite(
-          invoiceItem.ChargeDate.toLocalDate,
+          LocalDate.now(),
           chargeAmountToRefund,
           refundGuid,
           invoiceItem.InvoiceId,

--- a/src/test/scala/com/gu/invoicing/refund/SpreadRefundAcrossItemsSpec.scala
+++ b/src/test/scala/com/gu/invoicing/refund/SpreadRefundAcrossItemsSpec.scala
@@ -2,8 +2,7 @@ package com.gu.invoicing.refund
 
 import com.gu.invoicing.refund.Model._
 
-import java.time.LocalDateTime
-import java.time.format.DateTimeFormatter
+import java.time.LocalDate
 import scala.io.Source
 
 class SpreadRefundAcrossItemsSpec extends munit.FunSuite {
@@ -50,9 +49,7 @@ class SpreadRefundAcrossItemsSpec extends munit.FunSuite {
       14.42,
       "xxxxxxx",
     )
-    val expectedAdjustmentDate = LocalDateTime
-      .parse("2023-08-09T13:12:26.000+01:00", DateTimeFormatter.ISO_OFFSET_DATE_TIME)
-      .toLocalDate
+    val expectedAdjustmentDate = LocalDate.now()
     assertEquals(adjustments.head.AdjustmentDate, expectedAdjustmentDate)
   }
   test("spreadRefundAcrossItems function should work when there is more than one invoice on the same day") {

--- a/src/test/scala/com/gu/invoicing/refund/SpreadRefundAcrossItemsSpec.scala
+++ b/src/test/scala/com/gu/invoicing/refund/SpreadRefundAcrossItemsSpec.scala
@@ -2,7 +2,7 @@ package com.gu.invoicing.refund
 
 import com.gu.invoicing.refund.Model._
 
-import java.time.LocalDate
+import java.time.{LocalDate, ZoneId}
 import scala.io.Source
 
 class SpreadRefundAcrossItemsSpec extends munit.FunSuite {
@@ -49,7 +49,7 @@ class SpreadRefundAcrossItemsSpec extends munit.FunSuite {
       14.42,
       "xxxxxxx",
     )
-    val expectedAdjustmentDate = LocalDate.now()
+    val expectedAdjustmentDate = LocalDate.now(ZoneId.of("Europe/London"))
     assertEquals(adjustments.head.AdjustmentDate, expectedAdjustmentDate)
   }
   test("spreadRefundAcrossItems function should work when there is more than one invoice on the same day") {


### PR DESCRIPTION
## What does this change?

### Problem
In #184 the `AdjustmentDate` of an Invoice Item Adjustment was made to align with the date of the original invoice.

This introduces a bug where if a refund is attempted against a payment made in the previous month, the refund succeeds but the subsequent adjustment fails due to a `ACCOUNTING_PERIOD_CLOSED` error. This is because the AdjustmentDate, set to the original charge date, is in the previous accounting period which closes at month end. 

The AdjustmentDate should ALWAYS be set to the current date to avoid this.

This error crops up fairly often in the first half of each month, with 66 in the past 6 months at time of writing:
<img width="1400" alt="Screenshot 2024-04-02 at 17 00 04" src="https://github.com/guardian/invoicing-api/assets/23298731/789e9d51-836c-4736-9a15-cc0c06630e02">

The `AdjustmentDate` for the separate tax adjustment is still set correctly to be the current date, so often this will fail partially:
<img width="981" alt="Screenshot 2024-04-02 at 15 31 21" src="https://github.com/guardian/invoicing-api/assets/23298731/a5782f29-cd9c-47c4-933d-195281c0225d">

The impact on the customer is that the invoice balance is reopened after the refund, which means Zuora will try to take the payment again. This extra payment will need to be manually refunded and the invoice adjusted by a CSR.

### Fix
We revert the change in #184 to solve the issue with adjustments being made in a previous accounting period, but we also add `ZoneId.of("Europe/London")` to ensure that the current date is evaluated to the Europe/London timezone which should match the timezone setup in Zuora and avoid the original bug.
