### PR TITLE
Migrate alarms

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -27,27 +27,6 @@ Resources:
   # ****************************************************************************
   # Alarms
   # ****************************************************************************
-  FailedRefundAlarm:
-    Type: AWS::CloudWatch::Alarm
-    Condition: IsProd
-    Properties:
-      AlarmName: "URGENT 9-5 - PROD: Failed to apply refund to Zuora invoice"
-      AlarmDescription: Urgently perform manual cleanup as documented at https://github.com/guardian/invoicing-api
-      AlarmActions:
-        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:MarioTest
-      ComparisonOperator: GreaterThanOrEqualToThreshold
-      Dimensions:
-        - Name: FunctionName
-          Value: !Ref RefundLambda
-      EvaluationPeriods: 1
-      MetricName: Errors
-      Namespace: AWS/Lambda
-      Period: 300
-      Statistic: Sum
-      Threshold: 1
-      TreatMissingData: notBreaching
-    DependsOn:
-      - InvoicingLambdaRole
 
   FailedInvoicesAlarm:
     Type: AWS::CloudWatch::Alarm
@@ -59,7 +38,7 @@ Resources:
         - https://github.com/guardian/invoicing-api/blob/main/src/main/scala/com/gu/invoicing/invoice/README.md
         - export AWS_DEFAULT_REGION=eu-west-1 && awslogs get --profile membership /aws/lambda/invoicing-api-invoices-PROD --start='DD/mm/yyyy HH:MM' --end='DD/mm/yyyy HH:MM'
       AlarmActions:
-        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:MarioTest
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:alarms-handler-topic-PROD
       ComparisonOperator: GreaterThanOrEqualToThreshold
       Dimensions:
         - Name: FunctionName
@@ -84,7 +63,7 @@ Resources:
         - https://github.com/guardian/invoicing-api/blob/main/src/main/scala/com/gu/invoicing/pdf/README.md
         - export AWS_DEFAULT_REGION=eu-west-1 && awslogs get --profile membership /aws/lambda/invoicing-api-pdf-PROD --start='DD/mm/yyyy HH:MM' --end='DD/mm/yyyy HH:MM'
       AlarmActions:
-        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:MarioTest
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:alarms-handler-topic-PROD
       ComparisonOperator: GreaterThanOrEqualToThreshold
       Dimensions:
         - Name: FunctionName
@@ -109,7 +88,7 @@ Resources:
         - https://github.com/guardian/invoicing-api/blob/main/src/main/scala/com/gu/invoicing/nextinvoicedate/README.md
         - export AWS_DEFAULT_REGION=eu-west-1 && awslogs get --profile membership /aws/lambda/invoicing-api-nextinvoicedate-PROD --start='DD/mm/yyyy HH:MM' --end='DD/mm/yyyy HH:MM'
       AlarmActions:
-        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:MarioTest
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:alarms-handler-topic-PROD
       ComparisonOperator: GreaterThanOrEqualToThreshold
       Dimensions:
         - Name: FunctionName
@@ -134,7 +113,7 @@ Resources:
         - https://github.com/guardian/invoicing-api/blob/main/src/main/scala/com/gu/invoicing/preview/README.md
         - export AWS_DEFAULT_REGION=eu-west-1 && awslogs get --profile membership /aws/lambda/invoicing-api-preview-PROD --start='DD/mm/yyyy HH:MM' --end='DD/mm/yyyy HH:MM'
       AlarmActions:
-        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:MarioTest
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:alarms-handler-topic-PROD
       ComparisonOperator: GreaterThanOrEqualToThreshold
       Dimensions:
         - Name: FunctionName

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -50,6 +50,9 @@ Resources:
       Statistic: Sum
       Threshold: 1
       TreatMissingData: notBreaching
+      Tags:
+        - Key: App
+          Value: invoicing-api
     DependsOn:
       - InvoicingLambdaRole
 
@@ -75,6 +78,9 @@ Resources:
       Statistic: Sum
       Threshold: 1
       TreatMissingData: notBreaching
+      Tags:
+        - Key: App
+          Value: invoicing-api
     DependsOn:
       - InvoicingLambdaRole
 
@@ -100,6 +106,9 @@ Resources:
       Statistic: Sum
       Threshold: 1
       TreatMissingData: notBreaching
+      Tags:
+        - Key: App
+          Value: invoicing-api
     DependsOn:
       - InvoicingLambdaRole
 
@@ -125,6 +134,9 @@ Resources:
       Statistic: Sum
       Threshold: 1
       TreatMissingData: notBreaching
+      Tags:
+        - Key: App
+          Value: invoicing-api
     DependsOn:
       - InvoicingLambdaRole
 

--- a/src/main/scala/com/gu/invoicing/refund/README.md
+++ b/src/main/scala/com/gu/invoicing/refund/README.md
@@ -1,6 +1,10 @@
 
 ## Refund
 
+The refund endpoint is used only by the product-move-api refund lambda.
+
+If the lambda fails, a 5XX is returned and the calling lambda will leave the event on the refund queue.
+
 ### Example request
 
 Request


### PR DESCRIPTION
1. migrates alarms to use the new SNS topic. This means the alarms will go to the growth team's google chat channel
2. removes the refund lambda alarm. This lambda fails frequently because subscriptions are not in the correct state for refunding, e.g. pending direct debit payment. It's up to the calling lambda (in product-move-api) to retry these and handle errors.

Note - we believe the refund lambda logic could be moved into the relevant product-move-api lambda, as this is the only service that uses it. There may be other lambdas in this project that could also be moved.