### PR TITLE
feat: remove hard-coded invoice template IDs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ project/boot/
 project/plugins/project/
 metals.sbt
 .sc
+.metals

--- a/src/main/scala/com/gu/invoicing/common/ZuoraAuth.scala
+++ b/src/main/scala/com/gu/invoicing/common/ZuoraAuth.scala
@@ -24,12 +24,6 @@ object ZuoraAuth extends JsonSupport {
       case "PROD" => "https://rest.zuora.com"
     }
 
-  lazy val GNMAustralia_InvoiceTemplateID: String =
-    stage match {
-      case "CODE" => "2c92c0f85ecc47e5015ee7360d602757"
-      case "PROD" => "2c92a0fd5ecce80c015ee71028643020"
-    } // GNM Australia Pty Ltd
-
   /** Because list invoices is hit frequently JVM is kept warm and val access token would seem to persist across lambda
     * executions which meant the token would expire after one hour and because it was val it would not be requested
     * again. Hence now we periodically refreshes the token (making it def would have performance penalty)

--- a/src/main/scala/com/gu/invoicing/pdf/Impl.scala
+++ b/src/main/scala/com/gu/invoicing/pdf/Impl.scala
@@ -1,6 +1,6 @@
 package com.gu.invoicing.pdf
 
-import com.gu.invoicing.common.ZuoraAuth.{accessToken, zuoraApiHost, GNMAustralia_InvoiceTemplateID}
+import com.gu.invoicing.common.ZuoraAuth.{accessToken, zuoraApiHost}
 import com.gu.invoicing.pdf.Model._
 import com.gu.invoicing.common.Http
 import scala.util.chaining._
@@ -22,17 +22,6 @@ object Impl {
       .asString
       .body
       .pipe(read[PutResponse](_))
-
-  def setGNMAustraliaInvoiceTemplateId(accountId: String): PutResponse = {
-    Http(s"$zuoraApiHost/v1/object/account/$accountId")
-      .header("Authorization", s"Bearer $accessToken")
-      .put(
-        s"""{"InvoiceTemplateId":"$GNMAustralia_InvoiceTemplateID"}""",
-      )
-      .asString
-      .body
-      .pipe(read[PutResponse](_))
-  }
 
   def getAccount(accountId: String): Account =
     Http(s"$zuoraApiHost/v1/accounts/$accountId")

--- a/src/main/scala/com/gu/invoicing/pdf/Model.scala
+++ b/src/main/scala/com/gu/invoicing/pdf/Model.scala
@@ -16,7 +16,7 @@ object Model extends JsonSupport {
       AccountId: String,
       Body: String, /* Base64 encoded PDF */
   )
-  case class BasicInfo(IdentityId__c: String, invoiceTemplateId: String)
+  case class BasicInfo(IdentityId__c: String)
   case class BillingAndPayment(currency: String)
   case class SoldToContact(country: String)
   case class Account(

--- a/src/main/scala/com/gu/invoicing/pdf/Program.scala
+++ b/src/main/scala/com/gu/invoicing/pdf/Program.scala
@@ -3,7 +3,6 @@ package com.gu.invoicing.pdf
 import com.gu.invoicing.pdf.Model._
 import com.gu.invoicing.pdf.Impl._
 import com.gu.invoicing.common.Retry._
-import com.gu.invoicing.common.ZuoraAuth.{GNMAustralia_InvoiceTemplateID}
 
 import java.lang.System.getenv
 
@@ -18,21 +17,6 @@ object Program {
       identityId == account.basicInfo.IdentityId__c,
       s"Requested invoice id: $invoiceId appears to belong to different identity: ${account.basicInfo.IdentityId__c}",
     )
-    if (repairRequired(account)) {
-      setGNMAustraliaInvoiceTemplateId(invoice.AccountId)
-      regenerateInvoice(invoice.Id)
-      getInvoice(invoice.Id).Body
-    } else {
-      invoice.Body
-    }
+    invoice.Body
   }
-
-  // If the sold to country is Australia, the currency is AUD but the invoice template ID is not the correct one,
-  // then repair things by setting the correct invoice template ID, regenerating the PDF, and re-getting the PDF body.
-  private def repairRequired(account: Account): Boolean = {
-    account.soldToContact.country == "Australia" &&
-    account.billingAndPayment.currency == "AUD" &&
-    account.basicInfo.invoiceTemplateId != GNMAustralia_InvoiceTemplateID
-  }
-
 }


### PR DESCRIPTION
## What does this change?

[Trello](https://trello.com/c/h7MX4D5w/260-remove-all-references-to-hard-coded-invoice-template-ids-and-move-all-customers-to-new-invoice-template)

This removes all references to hard-coded invoice template IDs.

## Why are you doing this?

We have recently created a [generic HTML template](https://github.com/guardian/zuora-config/blob/main/finance/invoice-templates/system-default.html) that will be used by default for all products / accounts.

