### PR TITLE
skip refunding payments in Error state

### DIFF
--- a/src/main/scala/com/gu/invoicing/refund/Impl.scala
+++ b/src/main/scala/com/gu/invoicing/refund/Impl.scala
@@ -1,14 +1,12 @@
 package com.gu.invoicing.refund
 
+import com.gu.invoicing.common.Assert.StringAssert
+import com.gu.invoicing.common.Http
 import com.gu.invoicing.common.ZuoraAuth.{accessToken, zuoraApiHost}
+import com.gu.invoicing.refund.Model._
 
 import java.time.{LocalDate, ZoneId}
-import com.gu.invoicing.common.Http
-
 import scala.annotation.tailrec
-import Model._
-import com.gu.invoicing.common.Assert.StringAssert
-
 import scala.util.chaining._
 
 /** Zuora API client and implementation details
@@ -52,6 +50,9 @@ object Impl {
       .reverse
       .headOption
       .map(_.PaymentId)
+
+  def getPayment(paymentKey: String): PaymentStatus =
+    get[Payment](s"$zuoraApiHost/v1/payments/$paymentKey").status
 
   def createRefundObject(amount: BigDecimal, paymentId: String, comment: String): String =
     post[RefundResult](

--- a/src/test/scala/com/gu/invoicing/refund/InputSerialisationSuite.scala
+++ b/src/test/scala/com/gu/invoicing/refund/InputSerialisationSuite.scala
@@ -1,7 +1,6 @@
 package com.gu.invoicing.refund
 
-import com.gu.invoicing.refund.Model.RefundInput
-import Model._
+import com.gu.invoicing.refund.Model.{RefundInput, _}
 
 class InputSerialisationSuite extends munit.FunSuite {
   test("Serialisation works when adjustInvoices parameter is omitted") {
@@ -37,4 +36,64 @@ class InputSerialisationSuite extends munit.FunSuite {
                         |}""".stripMargin
     assertEquals(read[InvoiceItemQueryResult](inputString).records.head.amountWithTax, BigDecimal(12))
   }
+
+  test("can deserialise a payment response") {
+    val testData = TestData.paymentResponse
+    val actual = read[Payment](testData)
+    val expected = Payment(PaymentStatus.Processed)
+    assertEquals(actual, expected)
+  }
+}
+
+object TestData {
+  val paymentResponse =
+    """{
+      |"accountId": "4028905f5a87c0ff015a87d25ae90025",
+      |"accountNumber": "A00000001",
+      |"amount": 44.1,
+      |"appliedAmount": 44.1,
+      |"authTransactionId": null,
+      |"bankIdentificationNumber": null,
+      |"cancelledOn": null,
+      |"comment": "normal payment",
+      |"createdById": "402881e522cf4f9b0122cf5d82860002",
+      |"createdDate": "2017-03-01 11:30:37",
+      |"creditBalanceAmount": 0,
+      |"currency": "USD",
+      |"effectiveDate": "2017-03-01",
+      |"financeInformation": {
+      |"bankAccountAccountingCode": null,
+      |"bankAccountAccountingCodeType": null,
+      |"transferredToAccounting": "No",
+      |"unappliedPaymentAccountingCode": null,
+      |"unappliedPaymentAccountingCodeType": null
+      |},
+      |"gatewayId": null,
+      |"gatewayOrderId": null,
+      |"gatewayReconciliationReason": null,
+      |"gatewayReconciliationStatus": null,
+      |"gatewayResponse": null,
+      |"gatewayResponseCode": null,
+      |"gatewayState": "NotSubmitted",
+      |"id": "4028905f5a87c0ff015a87eb6b75007f",
+      |"markedForSubmissionOn": null,
+      |"number": "P-00000001",
+      |"paymentGatewayNumber": "PG-00000001",
+      |"paymentMethodId": "402881e522cf4f9b0122cf5dc4020045",
+      |"paymentMethodSnapshotId": null,
+      |"payoutId": null,
+      |"referenceId": null,
+      |"refundAmount": 0,
+      |"secondPaymentReferenceId": null,
+      |"settledOn": null,
+      |"softDescriptor": null,
+      |"softDescriptorPhone": null,
+      |"status": "Processed",
+      |"submittedOn": null,
+      |"success": true,
+      |"type": "External",
+      |"unappliedAmount": 0,
+      |"updatedById": "402881e522cf4f9b0122cf5d82860002",
+      |"updatedDate": "2017-03-01 11:30:37"
+      |}""".stripMargin
 }


### PR DESCRIPTION
We noticed that if someone is in payment failure for some reason, and tries to get a refund on the invoice via the S+ refund queue, it keeps erroring, as the payment can't actually be refunded.

This PR updates invocing API so it will just ignore the refund step if the payemnt is in Error status and carry on with the invoice balancing.

This endpoint only seems to be called from the one place, in supporter plus refund https://github.com/guardian/support-service-lambdas/blob/8efb438fab59867be679d16d7164fdbb322a7760/handlers/product-move-api/src/main/scala/com/gu/productmove/refund/RefundSupporterPlus.scala#L47

Tested in CODE on an Error and a Processed payment.